### PR TITLE
Add format check to CI pipeline

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Run Lint
         run: pnpm lint
 
+      - name: Run Format
+        run: pnpm format
+
       - name: Run Tests
         run: pnpm test
   build:


### PR DESCRIPTION
Related to the comment here https://github.com/exwestafrican/wagmi-frontend/pull/15/files#r2623297937 . We want CI to check for formatting issues and fail the build if any are found. 