### PR TITLE
Load Teammate details

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,6 +12,7 @@ export const ApiPaths = {
 	ROADMAP_FEATURE_REQUEST: "/roadmap/feature-request",
 	ROADMAP_FUTURE_FEATURES: "/roadmap/future-features",
 	INVITE_TEAMMATES: "/workspace/invite-teammates",
+	CURRENT_TEAMMATE: "/teammates/me",
 	VERIFY_INVITE: "/workspace/verify-invite",
 	ACCEPT_INVITE: "workspace/accept-invite",
 } as const

--- a/src/features/workspace/accept-invite.tsx
+++ b/src/features/workspace/accept-invite.tsx
@@ -86,16 +86,14 @@ export function AcceptInvite() {
 			return
 		}
 
-        console.log("accept invite",
-            {
-                workspaceCode: decodedData.workspaceCode,
-                inviteCode: decodedData.inviteCode,
-                teammateEmail: decodedData.recipientEmail,
-                firstName: values.firstName,
-                lastName: values.lastName,
-                username: values.username,
-            }
-            )
+		console.log("accept invite", {
+			workspaceCode: decodedData.workspaceCode,
+			inviteCode: decodedData.inviteCode,
+			teammateEmail: decodedData.recipientEmail,
+			firstName: values.firstName,
+			lastName: values.lastName,
+			username: values.username,
+		})
 
 		acceptInvite(
 			{

--- a/src/features/workspace/accept-invite.tsx
+++ b/src/features/workspace/accept-invite.tsx
@@ -86,6 +86,17 @@ export function AcceptInvite() {
 			return
 		}
 
+        console.log("accept invite",
+            {
+                workspaceCode: decodedData.workspaceCode,
+                inviteCode: decodedData.inviteCode,
+                teammateEmail: decodedData.recipientEmail,
+                firstName: values.firstName,
+                lastName: values.lastName,
+                username: values.username,
+            }
+            )
+
 		acceptInvite(
 			{
 				workspaceCode: decodedData.workspaceCode,

--- a/src/features/workspace/accept-invite.tsx
+++ b/src/features/workspace/accept-invite.tsx
@@ -86,15 +86,6 @@ export function AcceptInvite() {
 			return
 		}
 
-		console.log("accept invite", {
-			workspaceCode: decodedData.workspaceCode,
-			inviteCode: decodedData.inviteCode,
-			teammateEmail: decodedData.recipientEmail,
-			firstName: values.firstName,
-			lastName: values.lastName,
-			username: values.username,
-		})
-
 		acceptInvite(
 			{
 				workspaceCode: decodedData.workspaceCode,

--- a/src/features/workspace/accept-invite.tsx
+++ b/src/features/workspace/accept-invite.tsx
@@ -116,6 +116,10 @@ export function AcceptInvite() {
 		return <InvalidInviteScreen />
 	}
 
+	if (verificationError) {
+		return <InvalidInviteScreen />
+	}
+
 	if (verificationCompleted) {
 		return (
 			<SplitLayout>

--- a/src/features/workspace/api/current-teammate.ts
+++ b/src/features/workspace/api/current-teammate.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query"
+import { ApiPaths } from "@/constants.ts"
+import { apiClient } from "@/lib/api-client.ts"
+import type { Teammate } from "@/features/workspace/interface/teammate.interface.ts"
+
+export const CURRENT_TEAMMATE_QUERY_KEY = "current-teammate"
+
+export function useCurrentTeammate(workspaceCode: string) {
+	return useQuery<Teammate>({
+		queryKey: [CURRENT_TEAMMATE_QUERY_KEY, workspaceCode],
+		queryFn: async () => {
+			const res = await apiClient.get<Teammate>(ApiPaths.CURRENT_TEAMMATE, {
+				params: { workspaceCode },
+			})
+			return res.data
+		},
+		enabled: Boolean(workspaceCode),
+		staleTime: Number.POSITIVE_INFINITY,
+		refetchOnWindowFocus: false,
+	})
+}

--- a/src/features/workspace/interface/teammate.interface.ts
+++ b/src/features/workspace/interface/teammate.interface.ts
@@ -1,0 +1,6 @@
+export interface Teammate {
+	id: string
+	email: string
+	firstName: string
+	lastName: string
+}

--- a/src/features/workspace/invite-teammate.test.tsx
+++ b/src/features/workspace/invite-teammate.test.tsx
@@ -1,11 +1,13 @@
 import renderWithQueryClient, {
 	createTestQueryClient,
 } from "@/common/renderWithQueryClient.tsx"
+import { ApiPaths } from "@/constants.ts"
 import { WorkspaceStatus } from "@/features/workspace/interface/workspace.interface.ts"
 import LanguageProvider from "@/i18n/LanguageProvider"
 import { apiClient } from "@/lib/api-client.ts"
 import { useAuthStore } from "@/stores/auth.store.ts"
 import { WorkspaceCode } from "@/test/constants.ts"
+import { teammateFactory } from "@/test/factory/teammate.ts"
 import { enterEmailToInvite } from "@/test/helpers/invite-teammates.tsx"
 import { makeTestRouter } from "@/test/helpers/navigate.tsx"
 import { RouterProvider } from "@tanstack/react-router"
@@ -26,7 +28,15 @@ describe("Invite Teammate", () => {
 		const queryClient = createTestQueryClient()
 		const router = makeTestRouter()
 		useAuthStore.getState().setAuthToken("fake-token")
-		vi.mocked(apiClient.get).mockResolvedValue({ data: envoyeWorkspace })
+		vi.mocked(apiClient.get).mockImplementation((url: string) => {
+			if (url === ApiPaths.WORKSPACE) {
+				return Promise.resolve({ data: envoyeWorkspace })
+			}
+			if (url === ApiPaths.CURRENT_TEAMMATE) {
+				return Promise.resolve({ data: teammateFactory.build() })
+			}
+			return Promise.reject(new Error(`Unexpected GET ${url}`))
+		})
 		await router.navigate({
 			to: "/workspace",
 			search: { code: "test-workspace-code" },

--- a/src/features/workspace/workspace.page.tsx
+++ b/src/features/workspace/workspace.page.tsx
@@ -1,3 +1,4 @@
+import { Skeleton } from "@/components/ui/skeleton"
 import {
 	SidebarHeader,
 	SidebarProvider,
@@ -24,7 +25,8 @@ export default function WorkspacePage() {
 	const [openTeammateInviteModal, setOpenTeammateInviteModal] = useState(false)
 	const { code } = useSearch({ from: "/workspace" })
 	const { data: workspaceDataResponse } = useWorkspace(code)
-	const { data: teammate } = useCurrentTeammate(code)
+	const { data: teammate, isPending: isTeammateLoading } =
+		useCurrentTeammate(code)
 	const isMobile = useIsMobile()
 
 	const workspace = workspaceDataResponse?.data ?? ({} as Workspace) //TODO we should have workspace before here
@@ -38,10 +40,14 @@ export default function WorkspacePage() {
 			<SidebarProvider>
 				<Sidebar>
 					<SidebarHeader>
-						<div className="flex items-center justify-between">
-							<span className="text-gray-800 text-sm truncate">
-								{teammate?.email ?? ""}
-							</span>
+						<div className="flex items-center justify-between gap-2 min-w-0">
+							<div className="text-gray-800 text-sm truncate min-w-0 flex-1">
+								{isTeammateLoading ? (
+									<Skeleton className="h-4 w-44 max-w-full" />
+								) : (
+									(teammate?.email ?? "")
+								)}
+							</div>
 							<DropdownMenu>
 								<DropdownMenuTrigger asChild>
 									<button

--- a/src/features/workspace/workspace.page.tsx
+++ b/src/features/workspace/workspace.page.tsx
@@ -13,6 +13,7 @@ import {
 
 import { MoreVertical } from "lucide-react"
 import { useSearch } from "@tanstack/react-router"
+import { useCurrentTeammate } from "@/features/workspace/api/current-teammate.ts"
 import { useWorkspace } from "@/features/workspace/api/workspace.ts"
 import type { Workspace } from "@/features/workspace/interface/workspace.interface.ts"
 import { useIsMobile } from "@/hooks/use-mobile.ts"
@@ -23,6 +24,7 @@ export default function WorkspacePage() {
 	const [openTeammateInviteModal, setOpenTeammateInviteModal] = useState(false)
 	const { code } = useSearch({ from: "/workspace" })
 	const { data: workspaceDataResponse } = useWorkspace(code)
+	const { data: teammate } = useCurrentTeammate(code)
 	const isMobile = useIsMobile()
 
 	const workspace = workspaceDataResponse?.data ?? ({} as Workspace) //TODO we should have workspace before here
@@ -38,7 +40,7 @@ export default function WorkspacePage() {
 					<SidebarHeader>
 						<div className="flex items-center justify-between">
 							<span className="text-gray-800 text-sm truncate">
-								tumise.alade@useenvoye.com
+								{teammate?.email ?? ""}
 							</span>
 							<DropdownMenu>
 								<DropdownMenuTrigger asChild>

--- a/src/features/workspace/workspace.test.tsx
+++ b/src/features/workspace/workspace.test.tsx
@@ -11,11 +11,29 @@ import {
 	type Workspace,
 	WorkspaceStatus,
 } from "@/features/workspace/interface/workspace.interface.ts"
+import type { Teammate } from "@/features/workspace/interface/teammate.interface.ts"
+import { ApiPaths } from "@/constants.ts"
+import { teammateFactory } from "@/test/factory/teammate.ts"
 
 const envoyeWorkspace = {
 	code: WorkspaceCode.ENVOYE,
 	name: "Envoye",
 	status: WorkspaceStatus.ACTIVE,
+}
+
+function mockWorkspaceAndCurrentTeammate(
+	workspace: Workspace,
+	teammate: Teammate = teammateFactory.build(),
+) {
+	vi.mocked(apiClient.get).mockImplementation((url: string) => {
+		if (url === ApiPaths.WORKSPACE) {
+			return Promise.resolve({ data: workspace })
+		}
+		if (url === ApiPaths.CURRENT_TEAMMATE) {
+			return Promise.resolve({ data: teammate })
+		}
+		return Promise.reject(new Error(`Unexpected GET ${url}`))
+	})
 }
 
 describe("Workspace Test", () => {
@@ -25,9 +43,12 @@ describe("Workspace Test", () => {
 		user = userEvent.setup()
 	})
 
-	async function navigateToWorkspacePage(workspace: Workspace) {
+	async function navigateToWorkspacePage(
+		workspace: Workspace,
+		teammate: Teammate = teammateFactory.build(),
+	) {
 		useAuthStore.getState().setAuthToken("fake-token")
-		vi.mocked(apiClient.get).mockResolvedValue({ data: workspace })
+		mockWorkspaceAndCurrentTeammate(workspace, teammate)
 		return await navigateToTestPage({
 			to: "/workspace",
 			search: { code: workspace.code },
@@ -39,6 +60,21 @@ describe("Workspace Test", () => {
 		await user.click(menuTrigger)
 		await user.click(screen.getByRole("menuitem", { name: /add teammate/i }))
 	}
+
+	test("renders current teammate email in sidebar", async () => {
+		const sidebarEmail = "sidebar.user@useenvoye.com"
+		await navigateToWorkspacePage(
+			envoyeWorkspace,
+			teammateFactory.build({ email: sidebarEmail }),
+		)
+		expect(await screen.findByText(sidebarEmail)).toBeInTheDocument()
+		expect(apiClient.get).toHaveBeenCalledWith(
+			ApiPaths.CURRENT_TEAMMATE,
+			expect.objectContaining({
+				params: { workspaceCode: envoyeWorkspace.code },
+			}),
+		)
+	})
 
 	describe("workspace invite", () => {
 		test("on click cancel we close modal and clear all emails typed in by user", async () => {

--- a/src/test/factory/teammate.ts
+++ b/src/test/factory/teammate.ts
@@ -1,0 +1,10 @@
+import { faker } from "@faker-js/faker"
+import { Factory } from "fishery"
+import type { Teammate } from "@/features/workspace/interface/teammate.interface.ts"
+
+export const teammateFactory = Factory.define<Teammate>(() => ({
+	id: faker.string.uuid(),
+	email: faker.internet.email(),
+	firstName: faker.person.firstName(),
+	lastName: faker.person.lastName(),
+}))


### PR DESCRIPTION
## Summary 

When a teammate logs in, we want to dynamically load their details in the workspace.  Previously, the emal field was static

<img width="1787" height="740" alt="Screenshot 2026-04-11 at 19 30 36" src="https://github.com/user-attachments/assets/ac563e53-d357-460f-83e6-f330a76fec21" />
