### PR TITLE
Disable button to prevent multiple of same request.

### DIFF
--- a/src/features/auth/login-page.tsx
+++ b/src/features/auth/login-page.tsx
@@ -24,7 +24,7 @@ import { CHECK_MAIL_REASON } from "@/constants.ts"
 
 const LoginPage = () => {
 	const navigate = useNavigate()
-	const { mutate: loginUser } = useLogin()
+	const { mutate: loginUser, isPending } = useLogin()
 	const form = useForm<LoginData>({
 		resolver: zodResolver(loginSchema),
 		mode: "onChange",
@@ -83,11 +83,11 @@ const LoginPage = () => {
 							)}
 						/>
 						<Button
-							disabled={!form.formState.isValid}
+							disabled={!form.formState.isValid || isPending}
 							className="cursor-pointer"
 							type="submit"
 						>
-							Login
+							{isPending ? "Frolicking..." : "Login"}
 						</Button>
 
 						<p className="text-center text-sm text-neutral-600">

--- a/src/features/auth/signup-page.tsx
+++ b/src/features/auth/signup-page.tsx
@@ -24,7 +24,7 @@ import { SplitLayout } from "@/common/components/split-layout.tsx"
 import { CHECK_MAIL_REASON } from "@/constants.ts"
 
 const SignupPage = () => {
-	const { mutate: signupUser } = useSignup()
+	const { mutate: signupUser, isPending } = useSignup()
 	const navigate = useNavigate()
 
 	const form = useForm<SignupData>({
@@ -185,12 +185,12 @@ const SignupPage = () => {
 						/>
 
 						<Button
-							disabled={!form.formState.isValid}
+							disabled={!form.formState.isValid || isPending}
 							type="submit"
 							className="mt-2 h-11 w-full cursor-pointer rounded-lg bg-[#1A1C23] text-white hover:bg-[#1A1C23]/90"
 							data-testid="submit-button"
 						>
-							Sign Up
+							{isPending ? "Doodling.." : "Sign Up"}
 						</Button>
 
 						<p className="text-center text-sm text-neutral-600">


### PR DESCRIPTION
## Summary

Right now in prod, if you click the signup or login button multiple times, we either create multiple workspaces for the same request or send you multiple login emails. 

This is bad for several reasons, one we waste our email credits, two we have in unintended created workspaces. 

This PR aims to fix that. 


We should include this as one of our best practises or make it intentionally hard for anyone to create a button that does this by accident.  