### PR TITLE
Refactor: lets use admin client to make admin request

### DIFF
--- a/src/features/admin/api/list-tasks.ts
+++ b/src/features/admin/api/list-tasks.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query"
-import { apiClient } from "@/lib/api-client.ts"
+import { adminApiClient } from "@/lib/admin-api-client.ts"
 import { AdminApiPaths } from "@/constants.ts"
 
 export type Task = {
@@ -14,7 +14,7 @@ export function useTasks() {
 	return useQuery<Task[]>({
 		queryKey: [TASKS],
 		queryFn: async () => {
-			const res = await apiClient.get<Task[]>(AdminApiPaths.LIST_TASKS)
+			const res = await adminApiClient.get<Task[]>(AdminApiPaths.LIST_TASKS)
 			return res.data
 		},
 		staleTime: Number.POSITIVE_INFINITY,

--- a/src/features/admin/features/feature-flags/api/create-feature-flag.ts
+++ b/src/features/admin/features/feature-flags/api/create-feature-flag.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { AdminApiPaths } from "@/constants.ts"
-import { apiClient } from "@/lib/api-client.ts"
+import { adminApiClient } from "@/lib/admin-api-client.ts"
 import { FEATURE_FLAGS } from "@/features/admin/features/feature-flags/api/list-feature-flags.ts"
 import type { CreateFeatureFlagFormValues } from "@/features/admin/features/feature-flags/schema/create-feature-flag-schema.ts"
 
@@ -8,7 +8,7 @@ export function useCreateFeatureFlag() {
 	const queryClient = useQueryClient()
 	return useMutation({
 		mutationFn: (payload: CreateFeatureFlagFormValues) =>
-			apiClient.post(AdminApiPaths.FEATURE_FLAGS, payload),
+			adminApiClient.post(AdminApiPaths.FEATURE_FLAGS, payload),
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: [FEATURE_FLAGS] })
 		},

--- a/src/features/admin/features/feature-flags/api/delete-feature-flag.ts
+++ b/src/features/admin/features/feature-flags/api/delete-feature-flag.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { apiClient } from "@/lib/api-client.ts"
+import { adminApiClient } from "@/lib/admin-api-client.ts"
 import { AdminApiPaths } from "@/constants.ts"
 import { FEATURE_FLAGS } from "@/features/admin/features/feature-flags/api/list-feature-flags.ts"
 
@@ -7,7 +7,7 @@ export function useDeleteFeatureFlag() {
 	const queryClient = useQueryClient()
 	return useMutation({
 		mutationFn: (key: string) =>
-			apiClient.post(AdminApiPaths.DELETE_FEATURE_FLAG, { key }),
+			adminApiClient.post(AdminApiPaths.DELETE_FEATURE_FLAG, { key }),
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: [FEATURE_FLAGS] })
 		},

--- a/src/features/admin/features/feature-flags/api/list-feature-flags.ts
+++ b/src/features/admin/features/feature-flags/api/list-feature-flags.ts
@@ -3,7 +3,7 @@ import {
 	FeatureFlagStatus,
 	type FeatureFlag,
 } from "@/features/admin/interface/feature-flag.ts"
-import { apiClient } from "@/lib/api-client.ts"
+import { adminApiClient } from "@/lib/admin-api-client.ts"
 import { AdminApiPaths } from "@/constants.ts"
 
 export const FEATURE_FLAGS = "feature-flags"
@@ -29,7 +29,7 @@ export function useFeatureFlags() {
 	return useQuery<FeatureFlag[]>({
 		queryKey: [FEATURE_FLAGS],
 		queryFn: async () => {
-			const res = await apiClient.get<FeatureFlag[]>(
+			const res = await adminApiClient.get<FeatureFlag[]>(
 				AdminApiPaths.FEATURE_FLAGS,
 			)
 			return res.data.map((ff) => ({

--- a/src/features/admin/features/feature-flags/page.test.tsx
+++ b/src/features/admin/features/feature-flags/page.test.tsx
@@ -1,7 +1,7 @@
 import renderWithQueryClient from "@/common/renderWithQueryClient.tsx"
 import { AdminApiPaths } from "@/constants.ts"
 import AdminFeatureFlagPage from "@/features/admin/features/feature-flags/page.tsx"
-import { apiClient } from "@/lib/api-client.ts"
+import { adminApiClient } from "@/lib/admin-api-client.ts"
 import { featureFlagFactory } from "@/test/factory/feature-flag.ts"
 import { mockAuthedUser } from "@/test/helpers/mocks.ts"
 import { screen, waitFor } from "@testing-library/react"
@@ -10,8 +10,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 describe("AdminFeatureFlagPage", () => {
 	let user: UserEvent
-	const mockApiClientGet = vi.mocked(apiClient.get)
-	const mockApiClientPost = vi.mocked(apiClient.post)
+	const mockApiClientGet = vi.mocked(adminApiClient.get)
+	const mockApiClientPost = vi.mocked(adminApiClient.post)
 
 	beforeEach(() => {
 		user = userEvent.setup()

--- a/src/features/admin/features/login/api/login.ts
+++ b/src/features/admin/features/login/api/login.ts
@@ -1,12 +1,12 @@
 import { useMutation } from "@tanstack/react-query"
-import { apiClient } from "@/lib/api-client.ts"
+import { adminApiClient } from "@/lib/admin-api-client.ts"
 import { AdminApiPaths } from "@/constants.ts"
 import type { LoginData } from "@/features/auth/schema/loginSchema.ts"
 
 export function useAdminLogin() {
 	return useMutation({
 		mutationFn: (data: LoginData) => {
-			return apiClient.post(AdminApiPaths.LOGIN, data)
+			return adminApiClient.post(AdminApiPaths.LOGIN, data)
 		},
 	})
 }

--- a/src/lib/admin-api-client.ts
+++ b/src/lib/admin-api-client.ts
@@ -1,0 +1,4 @@
+import { createApiClient } from "@/lib/create-api-client"
+import { AdminPages } from "@/utils/pages"
+
+export const adminApiClient = createApiClient(AdminPages.LOGIN)

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,37 +1,4 @@
-import axios, { HttpStatusCode } from "axios"
-import { API_BASE_URL } from "@/constants"
-import { useAuthStore } from "@/stores/auth.store"
+import { createApiClient } from "@/lib/create-api-client"
 import { Pages } from "@/utils/pages"
 
-export const apiClient = axios.create({
-	baseURL: API_BASE_URL,
-})
-
-apiClient.interceptors.request.use((config) => {
-	const token = useAuthStore.getState().token
-	if (token) {
-		config.headers.Authorization = `Bearer ${token}`
-	}
-	return config
-})
-
-apiClient.interceptors.response.use(
-	(response) => response,
-	(error) => {
-		const status = error.response?.status
-		const hadAuthHeader = error.config?.headers?.Authorization
-
-		// Only redirect when we thought we were authenticated (had token)
-		// Avoid redirect on login/signup failures (no token = no redirect)
-		if (
-			(status === HttpStatusCode.Forbidden ||
-				status === HttpStatusCode.Unauthorized) &&
-			hadAuthHeader
-		) {
-			useAuthStore.getState().clearAuthToken()
-			const redirectUrl = encodeURIComponent(window.location.href)
-			window.location.href = `${Pages.LOGIN}?redirect=${redirectUrl}`
-		}
-		return Promise.reject(error)
-	},
-)
+export const apiClient = createApiClient(Pages.LOGIN)

--- a/src/lib/create-api-client.ts
+++ b/src/lib/create-api-client.ts
@@ -26,8 +26,7 @@ export function createApiClient(loginPath: string): AxiosInstance {
 			if (
 				(status === HttpStatusCode.Forbidden ||
 					status === HttpStatusCode.Unauthorized) &&
-				hadAuthHeader &&
-				window.location.pathname !== loginPath
+				hadAuthHeader
 			) {
 				useAuthStore.getState().clearAuthToken()
 				const redirectUrl = encodeURIComponent(window.location.href)

--- a/src/lib/create-api-client.ts
+++ b/src/lib/create-api-client.ts
@@ -1,0 +1,41 @@
+import axios, { type AxiosInstance, HttpStatusCode } from "axios"
+import { API_BASE_URL } from "@/constants"
+import { useAuthStore } from "@/stores/auth.store"
+
+export function createApiClient(loginPath: string): AxiosInstance {
+	const client = axios.create({
+		baseURL: API_BASE_URL,
+	})
+
+	client.interceptors.request.use((config) => {
+		const token = useAuthStore.getState().token
+		if (token) {
+			config.headers.Authorization = `Bearer ${token}`
+		}
+		return config
+	})
+
+	client.interceptors.response.use(
+		(response) => response,
+		(error) => {
+			const status = error.response?.status
+			const hadAuthHeader = error.config?.headers?.Authorization
+
+			// Only redirect when we thought we were authenticated (had token)
+			// Avoid redirect on login/signup failures (no token = no redirect)
+			if (
+				(status === HttpStatusCode.Forbidden ||
+					status === HttpStatusCode.Unauthorized) &&
+				hadAuthHeader &&
+				window.location.pathname !== loginPath
+			) {
+				useAuthStore.getState().clearAuthToken()
+				const redirectUrl = encodeURIComponent(window.location.href)
+				window.location.href = `${loginPath}?redirect=${redirectUrl}`
+			}
+			return Promise.reject(error)
+		},
+	)
+
+	return client
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -11,6 +11,16 @@ vi.mock("@/lib/api-client", () => ({
 	},
 }))
 
+vi.mock("@/lib/admin-api-client", () => ({
+	adminApiClient: {
+		get: vi.fn(),
+		post: vi.fn(),
+		put: vi.fn(),
+		patch: vi.fn(),
+		delete: vi.fn(),
+	},
+}))
+
 beforeEach(() => {
 	localStorage.clear()
 	window.location.hash = ""


### PR DESCRIPTION
## Summary

When the Admin's token expires, they get redirected to the workspace login page. We don't want that.  We want the user to get redirected to the Admin login page.