### PR TITLE
Add Envoye Composer and Basic Chat UI

### DIFF
--- a/src/components/ui/button-group.tsx
+++ b/src/components/ui/button-group.tsx
@@ -1,0 +1,83 @@
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Separator } from "@/components/ui/separator"
+
+const buttonGroupVariants = cva(
+  "flex w-fit items-stretch has-[>[data-slot=button-group]]:gap-2 [&>*]:focus-visible:relative [&>*]:focus-visible:z-10 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-md [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1",
+  {
+    variants: {
+      orientation: {
+        horizontal:
+          "[&>*:not(:first-child)]:rounded-l-none [&>*:not(:first-child)]:border-l-0 [&>*:not(:last-child)]:rounded-r-none",
+        vertical:
+          "flex-col [&>*:not(:first-child)]:rounded-t-none [&>*:not(:first-child)]:border-t-0 [&>*:not(:last-child)]:rounded-b-none",
+      },
+    },
+    defaultVariants: {
+      orientation: "horizontal",
+    },
+  }
+)
+
+function ButtonGroup({
+  className,
+  orientation,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof buttonGroupVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="button-group"
+      data-orientation={orientation}
+      className={cn(buttonGroupVariants({ orientation }), className)}
+      {...props}
+    />
+  )
+}
+
+function ButtonGroupText({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"div"> & {
+  asChild?: boolean
+}) {
+  const Comp = asChild ? Slot.Root : "div"
+
+  return (
+    <Comp
+      className={cn(
+        "flex items-center gap-2 rounded-md border bg-muted px-4 text-sm font-medium shadow-xs [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ButtonGroupSeparator({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="button-group-separator"
+      orientation={orientation}
+      className={cn(
+        "relative m-0! self-stretch bg-input data-[orientation=vertical]:h-auto",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  ButtonGroup,
+  ButtonGroupSeparator,
+  ButtonGroupText,
+  buttonGroupVariants,
+}

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,0 +1,56 @@
+import * as React from "react"
+import { ScrollArea as ScrollAreaPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function ScrollArea({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+  return (
+    <ScrollAreaPrimitive.Root
+      data-slot="scroll-area"
+      className={cn("relative", className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        data-slot="scroll-area-viewport"
+        className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  )
+}
+
+function ScrollBar({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) {
+  return (
+    <ScrollAreaPrimitive.ScrollAreaScrollbar
+      data-slot="scroll-area-scrollbar"
+      orientation={orientation}
+      className={cn(
+        "flex touch-none p-px transition-colors select-none",
+        orientation === "vertical" &&
+          "h-full w-2.5 border-l border-l-transparent",
+        orientation === "horizontal" &&
+          "h-2.5 flex-col border-t border-t-transparent",
+        className
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.ScrollAreaThumb
+        data-slot="scroll-area-thumb"
+        className="relative flex-1 rounded-full bg-border"
+      />
+    </ScrollAreaPrimitive.ScrollAreaScrollbar>
+  )
+}
+
+export { ScrollArea, ScrollBar }

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import { Separator as SeparatorPrimitive } from "radix-ui"
 

--- a/src/features/conversation/api/conversation-parts.ts
+++ b/src/features/conversation/api/conversation-parts.ts
@@ -1,0 +1,104 @@
+import { useQuery } from "@tanstack/react-query"
+
+export type ConversationPart = {
+	authorId: number
+	content: string
+	sentAt: number
+}
+
+const conversationParts: Record<number, ConversationPart[]> = {
+	1: [
+		{
+			authorId: 9,
+			content: "Good morning! Quick question about the sprint planning",
+			sentAt: 1780260845,
+		},
+		{
+			authorId: 7,
+			content: "Morning! What's up?",
+			sentAt: 1780260945,
+		},
+		{
+			authorId: 9,
+			content: "I noticed some dependencies might be blocking us",
+			sentAt: 1780261005,
+		},
+		{
+			authorId: 7,
+			content: "Which tickets are affected?",
+			sentAt: 1780261070,
+		},
+		{
+			authorId: 9,
+			content: "The authentication work is waiting on the API changes.",
+			sentAt: 1780261150,
+		},
+	],
+
+	2: [
+		{
+			authorId: 7,
+			content: "Hey, are we still on for the client demo today?",
+			sentAt: 1780262000,
+		},
+		{
+			authorId: 11,
+			content: "Yep, scheduled for 2 PM.",
+			sentAt: 1780262060,
+		},
+		{
+			authorId: 9,
+			content: "Perfect. I'll send over the latest build shortly.",
+			sentAt: 1780262130,
+		},
+		{
+			authorId: 11,
+			content: "Great, I'll review it before the call.",
+			sentAt: 1780262200,
+		},
+	],
+
+	3: [
+		{
+			authorId: 7,
+			content: "Did anyone investigate the production error from last night?",
+			sentAt: 1780263000,
+		},
+		{
+			authorId: 10,
+			content: "Yes, looks like a database connection timeout.",
+			sentAt: 1780263070,
+		},
+		{
+			authorId: 10,
+			content: "Was there any data loss?",
+			sentAt: 1780263140,
+		},
+		{
+			authorId: 7,
+			content: "No, requests were retried successfully.",
+			sentAt: 1780263200,
+		},
+		{
+			authorId: 10,
+			content: "Excellent. Let's add monitoring for it.",
+			sentAt: 1780263275,
+		},
+	],
+}
+
+export const TEAMMATE_CONVERSATION_PART = "teammate-conversation-part"
+
+export default function useConversationParts(
+	appCode: string,
+	conversationId: number,
+) {
+	return useQuery<ConversationPart[]>({
+		queryKey: [TEAMMATE_CONVERSATION_PART, conversationId, appCode],
+		queryFn: async () => {
+			const result: ConversationPart[] = conversationParts[conversationId] ?? []
+
+			return Promise.resolve(result)
+		},
+	})
+}

--- a/src/features/conversation/api/list-conversation.ts
+++ b/src/features/conversation/api/list-conversation.ts
@@ -1,0 +1,37 @@
+import { useQuery } from "@tanstack/react-query"
+
+export type TeammateConversationInfo = {
+	id: number
+	authorId: number
+	recipientId: number
+}
+
+export const TEAMMATE_CONVERSATION_LIST = "teammate-conversation-list"
+
+export default function useTeammateConversationInfo(
+	appCode: string,
+	adminId: number,
+) {
+	return useQuery<TeammateConversationInfo[]>({
+		queryKey: [TEAMMATE_CONVERSATION_LIST, adminId, appCode],
+		queryFn: async () => {
+			return Promise.resolve([
+				{
+					id: 1,
+					authorId: 7,
+					recipientId: 9,
+				},
+				{
+					id: 2,
+					authorId: 7,
+					recipientId: 11,
+				},
+				{
+					id: 3,
+					authorId: 7,
+					recipientId: 10,
+				},
+			])
+		},
+	})
+}

--- a/src/features/conversation/components/composer/envoy-composer.tsx
+++ b/src/features/conversation/components/composer/envoy-composer.tsx
@@ -1,0 +1,52 @@
+import { Field } from "@/components/ui/field.tsx"
+import { useState } from "react"
+import { Button } from "@/components/ui/button.tsx"
+import { SendHorizontal } from "lucide-react"
+import { cn } from "@/lib/utils.ts"
+
+const MAX_TEXT_INPUT = 2000
+
+export default function EnvoyComposer({
+	onEnter,
+}: { onEnter: (textInput: string) => void }) {
+	const [textInput, setTextInput] = useState("")
+	const hasNoInput = textInput.length == 0
+	const exceedsTextInput = textInput.length > MAX_TEXT_INPUT
+
+	const invalidInput = textInput.length > MAX_TEXT_INPUT
+	const disableSend = hasNoInput || exceedsTextInput
+	return (
+		<Field className={cn("w-full", "border border-gray-300", "rounded-md")}>
+			<textarea
+				value={textInput}
+				maxLength={MAX_TEXT_INPUT}
+				className="w-full bg-transparent border-none outline-none focus:outline-none text-sm placeholder:text-gray-400 resize-none px-3 pt-3 pb-2 min-h-[70px]"
+				placeholder="Message Raymond..."
+				onChange={(e) => setTextInput(e.target.value)}
+			/>
+			<div className="flex flex-row gap-4 items-center justify-end px-3 pb-2 pt-0">
+				<span
+					className={cn(
+						"text-xs",
+						invalidInput ? "text-red-600" : "text-gray-400",
+					)}
+				>
+					{textInput.length}/{MAX_TEXT_INPUT}
+				</span>
+
+				<Button
+					size="icon-sm"
+					className=" w-11 h-7 bg-green-950  hover:bg-green-950/90"
+					disabled={disableSend}
+					onClick={() => {
+						console.log("Sending...")
+						setTextInput("")
+						onEnter(textInput)
+					}}
+				>
+					<SendHorizontal />
+				</Button>
+			</div>
+		</Field>
+	)
+}

--- a/src/features/conversation/components/composer/envoy-composer.tsx
+++ b/src/features/conversation/components/composer/envoy-composer.tsx
@@ -10,7 +10,7 @@ export default function EnvoyComposer({
 	onEnter,
 }: { onEnter: (textInput: string) => void }) {
 	const [textInput, setTextInput] = useState("")
-	const hasNoInput = textInput.length == 0
+	const hasNoInput = textInput.length === 0
 	const exceedsTextInput = textInput.length > MAX_TEXT_INPUT
 
 	const invalidInput = textInput.length > MAX_TEXT_INPUT

--- a/src/features/conversation/components/text.tsx
+++ b/src/features/conversation/components/text.tsx
@@ -5,7 +5,7 @@ import { fullName } from "@/features/directory/utils/teammate.ts"
 export default function TextPart({
 	author,
 	content,
-}: { author: Teammate; content: string[] }) {
+}: { author: Teammate; content: { msg: string; timestamp: number }[] }) {
 	return (
 		<div className="flex flex-row gap-4 items-start">
 			<FallbackAvatar teammate={author} size="sm" />
@@ -17,8 +17,10 @@ export default function TextPart({
 						Today at 9:15pm{" "}
 					</span>
 				</div>
-				{content.map((msg) => (
-					<p className="text-sm font-normal">{msg}</p>
+				{content.map(({ msg, timestamp }) => (
+					<p key={timestamp} className="text-sm font-normal">
+						{msg}
+					</p>
 				))}
 			</div>
 		</div>

--- a/src/features/conversation/components/text.tsx
+++ b/src/features/conversation/components/text.tsx
@@ -1,0 +1,26 @@
+import FallbackAvatar from "@/features/directory/component/fallback-avatar.tsx"
+import type { Teammate } from "@/features/workspace/interface/teammate.interface.ts"
+import { fullName } from "@/features/directory/utils/teammate.ts"
+
+export default function TextPart({
+	author,
+	content,
+}: { author: Teammate; content: string[] }) {
+	return (
+		<div className="flex flex-row gap-4 items-start">
+			<FallbackAvatar teammate={author} size="sm" />
+			<div className="flex flex-col gap-0">
+				<div className="flex flex-row gap-1 items-center">
+					<h1 className="font-semibold text-sm">{fullName(author)}</h1>
+					<span className="text-xs font-normal text-gray-400">
+						{" "}
+						Today at 9:15pm{" "}
+					</span>
+				</div>
+				{content.map((msg) => (
+					<p className="text-sm font-normal">{msg}</p>
+				))}
+			</div>
+		</div>
+	)
+}

--- a/src/features/conversation/page.tsx
+++ b/src/features/conversation/page.tsx
@@ -55,7 +55,13 @@ export default function TeammateConversation() {
 						{allParts.map((part) => {
 							const author = registry.find(part.authorId)
 							return (
-								author && <TextPart author={author} content={[part.content]} />
+								author && (
+									<TextPart
+										key={`${part.authorId}-${part.sentAt}`}
+										author={author}
+										content={[{ msg: part.content, timestamp: part.sentAt }]}
+									/>
+								)
 							)
 						})}
 					</div>

--- a/src/features/conversation/page.tsx
+++ b/src/features/conversation/page.tsx
@@ -1,0 +1,80 @@
+import useTeammateConversationInfo from "@/features/conversation/api/list-conversation.ts"
+import { useSearch } from "@tanstack/react-router"
+import FallbackAvatar from "@/features/directory/component/fallback-avatar.tsx"
+import { Separator } from "@/components/ui/separator.tsx"
+import { fullName } from "@/features/directory/utils/teammate.ts"
+import TextPart from "@/features/conversation/components/text.tsx"
+import useTeammateInfoRegistry from "@/features/directory/hooks/use-teammate-Info-registry.ts"
+import useConversationParts, {
+	type ConversationPart,
+} from "@/features/conversation/api/conversation-parts.ts"
+import { useState } from "react"
+import { ScrollArea } from "@/components/ui/scroll-area.tsx"
+import EnvoyComposer from "@/features/conversation/components/composer/envoy-composer.tsx"
+import { useCurrentWorkspaceTeammate } from "@/features/workspace/api/current-teammate.ts"
+
+export default function TeammateConversation() {
+	const { code, conversationId } = useSearch({
+		from: "/workspace/conversation",
+	})
+
+	const { data: conversationParticipated } = useTeammateConversationInfo(
+		code,
+		1,
+	)
+	const registry = useTeammateInfoRegistry(code)
+	const { data: conversationParts } = useConversationParts(code, conversationId)
+	const conversationInfo = conversationParticipated?.find(
+		(convo) => convo.id === conversationId,
+	)
+	const { data: currentTeammate } = useCurrentWorkspaceTeammate(code)
+
+	const [localParts, setLocalParts] = useState<ConversationPart[]>([])
+
+	const allParts = conversationParts
+		? [...conversationParts, ...localParts]
+		: localParts
+
+	const participantInfo = conversationInfo
+		? registry.find(conversationInfo.recipientId)
+		: undefined
+
+	return (
+		participantInfo && (
+			<div className="flex flex-col h-full min-h-0">
+				<header className="px-4 pt-3 pb-3 flex gap-2 items-center">
+					<FallbackAvatar teammate={participantInfo} />
+					<h1 className="text-lg md:text-xl font-semibold">
+						{" "}
+						{fullName(participantInfo)}{" "}
+					</h1>
+				</header>
+				<Separator />
+				<ScrollArea className="flex-1 min-h-0">
+					<div className="px-4 py-3 flex flex-col gap-3 flex-1 ">
+						{allParts.map((part) => {
+							const author = registry.find(part.authorId)
+							return (
+								author && <TextPart author={author} content={[part.content]} />
+							)
+						})}
+					</div>
+				</ScrollArea>
+				<div className="px-4 py-3">
+					<EnvoyComposer
+						onEnter={(textInput) =>
+							setLocalParts((prev) => [
+								...prev,
+								{
+									authorId: currentTeammate?.id ?? 0,
+									content: textInput,
+									sentAt: Date.now(),
+								},
+							])
+						}
+					/>
+				</div>
+			</div>
+		)
+	)
+}

--- a/src/features/directory/component/fallback-avatar.tsx
+++ b/src/features/directory/component/fallback-avatar.tsx
@@ -1,0 +1,30 @@
+import type { Teammate } from "@/features/workspace/interface/teammate.interface.ts"
+import { cva, type VariantProps } from "class-variance-authority"
+import { cn } from "@/lib/utils.ts"
+
+const variant = cva(
+	"rounded-md  text-base font-semibold flex items-center justify-center border-2 border-solid",
+	{
+		variants: {
+			size: {
+				sm: "min-w-8 min-h-8 text-sm",
+				m: "min-w-10 min-h-10 text-base",
+			},
+		},
+		defaultVariants: {
+			size: "m",
+		},
+	},
+)
+
+type Props = {
+	teammate: Teammate
+} & VariantProps<typeof variant>
+export default function FallbackAvatar({ teammate, size = "m" }: Props) {
+	return (
+		<div className={cn(variant({ size }))}>
+			{" "}
+			{teammate.firstName.charAt(0).toUpperCase()}
+		</div>
+	)
+}

--- a/src/features/directory/hooks/use-teammate-Info-registry.ts
+++ b/src/features/directory/hooks/use-teammate-Info-registry.ts
@@ -1,0 +1,12 @@
+import useTeammates from "@/features/directory/api/teammates.ts"
+import indexBy from "@/utils/indexed-by.ts"
+
+export default function useTeammateInfoRegistry(code: string) {
+	const { data: teammates } = useTeammates(code)
+	const indexedTeammates = indexBy(teammates ?? [], (teammate) => teammate.id)
+	return {
+		find: (teammateId: number) => {
+			return indexedTeammates.get(teammateId)
+		},
+	}
+}

--- a/src/features/directory/team-member-card.tsx
+++ b/src/features/directory/team-member-card.tsx
@@ -5,7 +5,7 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@/components/ui/card.tsx"
-import { type Teammate } from "@/features/workspace/interface/teammate.interface.ts"
+import type { Teammate } from "@/features/workspace/interface/teammate.interface.ts"
 import {
 	buildTeammateRole,
 	formatRole,

--- a/src/features/directory/team-member-card.tsx
+++ b/src/features/directory/team-member-card.tsx
@@ -5,12 +5,12 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@/components/ui/card.tsx"
+import { type Teammate } from "@/features/workspace/interface/teammate.interface.ts"
 import {
 	buildTeammateRole,
 	formatRole,
 	fullName,
-	type Teammate,
-} from "@/features/workspace/interface/teammate.interface.ts"
+} from "@/features/directory/utils/teammate.ts"
 
 export default function TeamMemberCard({ teammate }: { teammate: Teammate }) {
 	const role = buildTeammateRole(teammate)

--- a/src/features/directory/utils/teammate.ts
+++ b/src/features/directory/utils/teammate.ts
@@ -1,0 +1,30 @@
+import sentenceCase from "@/utils/sentence-case.ts"
+import {
+	type Role,
+	ROLES,
+	type Teammate,
+} from "@/features/workspace/interface/teammate.interface.ts"
+
+export const fallBackRole: Role = {
+	name: "Unknown Role",
+	emoji: "💪🏾",
+	backgroundColor: "#fff8bb",
+	colorCode: "#5a5854",
+}
+
+export function fullName(teammate: Teammate) {
+	return [teammate.firstName, teammate.lastName]
+		.map((n) => sentenceCase(n))
+		.join(" ")
+}
+
+export function buildTeammateRole(teammate: Teammate) {
+	if (ROLES[teammate.role] === undefined) {
+		return fallBackRole
+	}
+	return ROLES[teammate.role]
+}
+
+export function formatRole(role: Role) {
+	return `${role.emoji} ${role.name}`
+}

--- a/src/features/workspace/interface/teammate.interface.ts
+++ b/src/features/workspace/interface/teammate.interface.ts
@@ -1,5 +1,3 @@
-import sentenceCase from "@/utils/sentence-case.ts"
-
 export interface Teammate {
 	id: number
 	email: string
@@ -16,7 +14,7 @@ export interface Role {
 	colorCode: string
 }
 
-const ROLES: Record<string, Role> = {
+export const ROLES: Record<string, Role> = {
 	WorkspaceAdmin: {
 		name: "Workspace Owner",
 		emoji: "👀",
@@ -35,28 +33,4 @@ const ROLES: Record<string, Role> = {
 		backgroundColor: "#FDE2E4", // soft red/pink
 		colorCode: "#9B1C1C", // deep red
 	},
-}
-
-const fallBackRole: Role = {
-	name: "Unknown Role",
-	emoji: "💪🏾",
-	backgroundColor: "#fff8bb",
-	colorCode: "#5a5854",
-}
-
-export function fullName(teammate: Teammate) {
-	return [teammate.firstName, teammate.lastName]
-		.map((n) => sentenceCase(n))
-		.join(" ")
-}
-
-export function buildTeammateRole(teammate: Teammate) {
-	if (ROLES[teammate.role] === undefined) {
-		return fallBackRole
-	}
-	return ROLES[teammate.role]
-}
-
-export function formatRole(role: Role) {
-	return `${role.emoji} ${role.name}`
 }

--- a/src/features/workspace/workspace.page.tsx
+++ b/src/features/workspace/workspace.page.tsx
@@ -187,6 +187,7 @@ export default function WorkspacePage() {
 							<DropdownMenu>
 								<DropdownMenuTrigger asChild>
 									<button
+										aria-label="Workspace menu"
 										type="button"
 										className="text-gray-600 hover:text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md px-1 py-1.5 transition-colors cursor-pointer"
 									>

--- a/src/features/workspace/workspace.page.tsx
+++ b/src/features/workspace/workspace.page.tsx
@@ -41,6 +41,9 @@ import { Separator } from "@/components/ui/separator"
 import { cn } from "@/lib/utils.ts"
 import useActivePath from "@/hooks/use-active-path.ts"
 import MainMenuItem from "@/features/workspace/components/main-menu-item.tsx"
+import useTeammateConversationInfo from "@/features/conversation/api/list-conversation.ts"
+import { fullName } from "@/features/directory/utils/teammate.ts"
+import useTeammateInfoRegistry from "@/features/directory/hooks/use-teammate-Info-registry.ts"
 
 type SideNavWithSeparatorProp = {
 	className?: string
@@ -90,10 +93,12 @@ export default function WorkspacePage() {
 	const { code } = useSearch({ from: "/workspace" })
 	const { data: workspaceDataResponse } = useWorkspace(code)
 	const { data: teammate } = useCurrentWorkspaceTeammate(code)
+	const { data: conversations } = useTeammateConversationInfo(code, 1)
 
 	const isMobile = useIsMobile()
 	const navigate = useNavigate()
 	const isActivePath = useActivePath()
+	const registry = useTeammateInfoRegistry(code)
 
 	const workspace = workspaceDataResponse?.data ?? ({} as Workspace) //TODO we should have workspace before here
 
@@ -112,7 +117,7 @@ export default function WorkspacePage() {
 		},
 		{
 			id: "conversation",
-			path: "/workspace/conversation",
+			path: "/workspace/conversations",
 			icon: MessagesSquare,
 			label: "Conversations",
 		},
@@ -150,6 +155,8 @@ export default function WorkspacePage() {
 	]
 
 	const badgeText = (count: number) => (count > 10 ? "10+" : count)
+	const conversationRoute = (conversationId: number) =>
+		`/workspace/conversation?code=${code}&conversationId=${conversationId}`
 
 	return (
 		<div>
@@ -260,6 +267,39 @@ export default function WorkspacePage() {
 							<SidebarGroupLabel className="sidebar-group-layout">
 								direct messages
 							</SidebarGroupLabel>
+							<SidebarMenu className="px-3 gap-0">
+								{conversations?.map((conversation) => {
+									const teammate = registry.find(conversation.recipientId)
+									const name = teammate
+										? fullName(teammate)
+										: "Unknown Teammate"
+
+									const route = conversationRoute(conversation.id)
+									console.log(route)
+									return (
+										<SidebarMenuItem>
+											<SidebarMenuButton
+												size="sm"
+												className="text-muted-brown text-xs cursor-pointer tracking-wide"
+												onClick={() =>
+													navigate({
+														from: "/workspace",
+														to: "/workspace/conversation",
+														search: {
+															code: code,
+															conversationId: conversation.id,
+														},
+													})
+												}
+												isActive={isActivePath(route)}
+											>
+												<div className="h-2 w-2 rounded-full bg-green-500" />
+												{name}
+											</SidebarMenuButton>
+										</SidebarMenuItem>
+									)
+								})}
+							</SidebarMenu>
 						</SideNavGroupWithTopSeparator>
 					</SidebarContent>
 				</Sidebar>

--- a/src/features/workspace/workspace.page.tsx
+++ b/src/features/workspace/workspace.page.tsx
@@ -275,9 +275,8 @@ export default function WorkspacePage() {
 										: "Unknown Teammate"
 
 									const route = conversationRoute(conversation.id)
-									console.log(route)
 									return (
-										<SidebarMenuItem>
+										<SidebarMenuItem key={conversation.id}>
 											<SidebarMenuButton
 												size="sm"
 												className="text-muted-brown text-xs cursor-pointer tracking-wide"

--- a/src/features/workspace/workspace.test.tsx
+++ b/src/features/workspace/workspace.test.tsx
@@ -1,43 +1,21 @@
-import { describe, expect, vi, test, beforeEach } from "vitest"
-import { navigateToTestPage } from "@/test/helpers/navigate"
+import { describe, expect, test, beforeEach } from "vitest"
 import { WorkspaceCode } from "@/test/constants.ts"
 import { screen, waitFor } from "@testing-library/react"
-import { useAuthStore } from "@/stores/auth.store.ts"
 import { apiClient } from "@/lib/api-client.ts"
 import type { UserEvent } from "@testing-library/user-event"
 import userEvent from "@testing-library/user-event"
 import { enterEmailToInvite } from "@/test/helpers/invite-teammates.tsx"
 import {
-	type Workspace,
 	WorkspaceStatus,
 } from "@/features/workspace/interface/workspace.interface.ts"
-import type { Teammate } from "@/features/workspace/interface/teammate.interface.ts"
 import { ApiPaths } from "@/constants.ts"
 import { teammateFactory } from "@/test/factory/teammate.ts"
+import { navigateToWorkspacePage } from "@/test/helpers/workspace.ts"
 
 const envoyeWorkspace = {
 	code: WorkspaceCode.ENVOYE,
 	name: "Envoye",
 	status: WorkspaceStatus.ACTIVE,
-}
-
-function mockWorkspaceAndCurrentTeammate(
-	workspace: Workspace,
-	teammate: Teammate = teammateFactory.build(),
-	workspaceTeammates: Teammate[] = [teammateFactory.build()],
-) {
-	vi.mocked(apiClient.get).mockImplementation((url: string) => {
-		if (url === ApiPaths.WORKSPACE) {
-			return Promise.resolve({ data: workspace })
-		}
-		if (url === ApiPaths.CURRENT_TEAMMATE) {
-			return Promise.resolve({ data: teammate })
-		}
-		if (url === ApiPaths.ACTIVE_TEAMMATES) {
-			return Promise.resolve({ data: workspaceTeammates })
-		}
-		return Promise.reject(new Error(`Unexpected GET ${url}`))
-	})
 }
 
 describe("Workspace Test", () => {
@@ -47,21 +25,8 @@ describe("Workspace Test", () => {
 		user = userEvent.setup()
 	})
 
-	async function navigateToWorkspacePage(
-		workspace: Workspace,
-		teammate: Teammate = teammateFactory.build(),
-		workspaceTeammates: Teammate[] = [teammateFactory.build()],
-	) {
-		useAuthStore.getState().setAuthToken("fake-token")
-		mockWorkspaceAndCurrentTeammate(workspace, teammate, workspaceTeammates)
-		return await navigateToTestPage({
-			to: "/workspace",
-			search: { code: workspace.code },
-		})
-	}
-
 	async function openInviteTeammateModal() {
-		const menuTrigger = screen.getByRole("button") // MoreVertical trigger
+		const menuTrigger = screen.getAllByRole("button")[0] // MoreVertical trigger
 		await user.click(menuTrigger)
 		await user.click(screen.getByRole("menuitem", { name: /add teammate/i }))
 	}

--- a/src/features/workspace/workspace.test.tsx
+++ b/src/features/workspace/workspace.test.tsx
@@ -5,9 +5,7 @@ import { apiClient } from "@/lib/api-client.ts"
 import type { UserEvent } from "@testing-library/user-event"
 import userEvent from "@testing-library/user-event"
 import { enterEmailToInvite } from "@/test/helpers/invite-teammates.tsx"
-import {
-	WorkspaceStatus,
-} from "@/features/workspace/interface/workspace.interface.ts"
+import { WorkspaceStatus } from "@/features/workspace/interface/workspace.interface.ts"
 import { ApiPaths } from "@/constants.ts"
 import { teammateFactory } from "@/test/factory/teammate.ts"
 import { navigateToWorkspacePage } from "@/test/helpers/workspace.ts"

--- a/src/features/workspace/workspace.test.tsx
+++ b/src/features/workspace/workspace.test.tsx
@@ -24,7 +24,7 @@ describe("Workspace Test", () => {
 	})
 
 	async function openInviteTeammateModal() {
-		const menuTrigger = screen.getAllByRole("button")[0] // MoreVertical trigger
+		const menuTrigger = screen.getByRole("button", { name: /workspace menu/i }) // MoreVertical trigger
 		await user.click(menuTrigger)
 		await user.click(screen.getByRole("menuitem", { name: /add teammate/i }))
 	}

--- a/src/routing/workspace.ts
+++ b/src/routing/workspace.ts
@@ -6,6 +6,7 @@ import { z } from "zod"
 import { rootRoute } from "@/routing/root.ts"
 import WorkspaceDirectoryPage from "@/features/directory/workspace-directory-page.tsx"
 import NotFound from "@/features/not-found.tsx"
+import TeammateConversation from "@/features/conversation/page.tsx"
 
 export const workspaceLayoutRoute = createRoute({
 	getParentRoute: () => rootRoute,
@@ -38,7 +39,20 @@ const workspaceDirectoryRoute = createRoute({
 	component: WorkspaceDirectoryPage,
 })
 
+const conversationRoute = createRoute({
+	getParentRoute: () => workspaceLayoutRoute,
+	path: "conversation",
+	validateSearch: (search) =>
+		z
+			.object({
+				conversationId: z.number(),
+			})
+			.parse(search),
+	component: TeammateConversation,
+})
+
 export const workspaceRouteTree = workspaceLayoutRoute.addChildren([
 	workspaceIndexRoute,
 	workspaceDirectoryRoute,
+	conversationRoute,
 ])

--- a/src/test/helpers/workspace.ts
+++ b/src/test/helpers/workspace.ts
@@ -1,0 +1,40 @@
+import type { Workspace } from "@/features/workspace/interface/workspace.interface.ts"
+import type { Teammate } from "@/features/workspace/interface/teammate.interface.ts"
+import { teammateFactory } from "@/test/factory/teammate.ts"
+import { useAuthStore } from "@/stores/auth.store.ts"
+import { navigateToTestPage } from "@/test/helpers/navigate.tsx"
+import { vi } from "vitest"
+import { apiClient } from "@/lib/api-client.ts"
+import { ApiPaths } from "@/constants.ts"
+
+export async function navigateToWorkspacePage(
+	workspace: Workspace,
+	teammate: Teammate = teammateFactory.build(),
+	workspaceTeammates: Teammate[] = [teammateFactory.build()],
+) {
+	useAuthStore.getState().setAuthToken("fake-token")
+	mockWorkspaceAndCurrentTeammate(workspace, teammate, workspaceTeammates)
+	return await navigateToTestPage({
+		to: "/workspace",
+		search: { code: workspace.code },
+	})
+}
+
+export function mockWorkspaceAndCurrentTeammate(
+	workspace: Workspace,
+	teammate: Teammate = teammateFactory.build(),
+	workspaceTeammates: Teammate[] = [teammateFactory.build()],
+) {
+	vi.mocked(apiClient.get).mockImplementation((url: string) => {
+		if (url === ApiPaths.WORKSPACE) {
+			return Promise.resolve({ data: workspace })
+		}
+		if (url === ApiPaths.CURRENT_TEAMMATE) {
+			return Promise.resolve({ data: teammate })
+		}
+		if (url === ApiPaths.ACTIVE_TEAMMATES) {
+			return Promise.resolve({ data: workspaceTeammates })
+		}
+		return Promise.reject(new Error(`Unexpected GET ${url}`))
+	})
+}

--- a/src/utils/indexed-by.ts
+++ b/src/utils/indexed-by.ts
@@ -1,0 +1,6 @@
+export default function indexBy<T, V>(
+	array: T[],
+	getKey: (item: T) => V,
+): Map<V, T> {
+	return new Map(array.map((item) => [getKey(item), item]))
+}


### PR DESCRIPTION
## Summary

In this PR, we setup a basic Composer to power teammate-to-teammate conversation.  When user clicks send, we add the message locally, no api calls made

https://github.com/user-attachments/assets/c60e5033-2b4b-45b3-ab4e-ff0f4ab872b1

