### PR TITLE
Collapse side-panel when user navigates to new conversation

### DIFF
--- a/src/features/conversation/new-conversation.page.tsx
+++ b/src/features/conversation/new-conversation.page.tsx
@@ -16,6 +16,7 @@ import { ScrollArea } from "@/components/ui/scroll-area.tsx"
 import { DESKTOP_KEYS } from "@/constants.ts"
 import { Badge } from "@/components/ui/badge.tsx"
 import { X } from "lucide-react"
+import {useSidebar} from "@/components/ui/sidebar.tsx";
 
 export function NewConversationPage() {
 	const { code } = useSearch({
@@ -25,10 +26,10 @@ export function NewConversationPage() {
 	const query = useTeammateFullNameSearch(code)
 	const placeholderName = usePlaceholderName()
 	const inputRef = useRef<HTMLInputElement>(null)
+    const { setOpenMobile } = useSidebar()
 
 	const [open, setOpen] = useState<boolean>(true)
 	const [queryText, setQueryText] = useState<string>("")
-
 	const [selectedTeammate, setSelectedTeammate] = useState<
 		Teammate | undefined
 	>(undefined)
@@ -41,6 +42,11 @@ export function NewConversationPage() {
 			inputRef.current?.focus()
 		}
 	}, [selectedTeammate])
+
+
+    useEffect(() => {
+         setOpenMobile(false)
+    }, []);
 
 	useEffect(() => {
 		if (selectedTeammate) {
@@ -114,7 +120,7 @@ export function NewConversationPage() {
 					alignOffset={19}
 					onOpenAutoFocus={(e) => e.preventDefault()}
 					onCloseAutoFocus={(e) => e.preventDefault()}
-					className="px-0 flex space-y-0 flex-col  w-[calc(var(--radix-popover-trigger-width)-36px)]"
+					className="p-0 flex space-y-0 flex-col  w-[calc(var(--radix-popover-trigger-width)-36px)]"
 				>
 					<ScrollArea>
 						{queryResult.slice(0, 10).map((teammate) => (

--- a/src/features/conversation/new-conversation.page.tsx
+++ b/src/features/conversation/new-conversation.page.tsx
@@ -16,7 +16,7 @@ import { ScrollArea } from "@/components/ui/scroll-area.tsx"
 import { DESKTOP_KEYS } from "@/constants.ts"
 import { Badge } from "@/components/ui/badge.tsx"
 import { X } from "lucide-react"
-import {useSidebar} from "@/components/ui/sidebar.tsx";
+import { useSidebar } from "@/components/ui/sidebar.tsx"
 
 export function NewConversationPage() {
 	const { code } = useSearch({
@@ -26,7 +26,7 @@ export function NewConversationPage() {
 	const query = useTeammateFullNameSearch(code)
 	const placeholderName = usePlaceholderName()
 	const inputRef = useRef<HTMLInputElement>(null)
-    const { setOpenMobile } = useSidebar()
+	const { setOpenMobile } = useSidebar()
 
 	const [open, setOpen] = useState<boolean>(true)
 	const [queryText, setQueryText] = useState<string>("")
@@ -43,10 +43,9 @@ export function NewConversationPage() {
 		}
 	}, [selectedTeammate])
 
-
-    useEffect(() => {
-         setOpenMobile(false)
-    }, []);
+	useEffect(() => {
+		setOpenMobile(false)
+	}, [setOpenMobile])
 
 	useEffect(() => {
 		if (selectedTeammate) {

--- a/src/features/workspace/workspace.page.tsx
+++ b/src/features/workspace/workspace.page.tsx
@@ -1,16 +1,16 @@
 import { Skeleton } from "@/components/ui/skeleton"
 import {
-	SidebarContent,
-	SidebarGroup,
-	SidebarGroupContent,
-	SidebarGroupLabel,
-	SidebarHeader,
-	SidebarMenu,
-	SidebarMenuBadge,
-	SidebarMenuButton,
-	SidebarMenuItem,
-	SidebarProvider,
-	SidebarTrigger,
+    SidebarContent,
+    SidebarGroup,
+    SidebarGroupContent,
+    SidebarGroupLabel,
+    SidebarHeader,
+    SidebarMenu,
+    SidebarMenuBadge,
+    SidebarMenuButton,
+    SidebarMenuItem,
+    SidebarProvider,
+    SidebarTrigger,
 } from "@/components/ui/sidebar.tsx"
 import { Sidebar } from "@/components/ui/sidebar"
 import {
@@ -165,7 +165,7 @@ export default function WorkspacePage() {
 				open={openTeammateInviteModal}
 				onOpenChange={setOpenTeammateInviteModal}
 			/>
-			<SidebarProvider>
+			<SidebarProvider >
 				<Sidebar>
 					<SidebarHeader className="p-3">
 						<div className="flex items-center justify-between gap-2 min-w-0">

--- a/src/features/workspace/workspace.page.tsx
+++ b/src/features/workspace/workspace.page.tsx
@@ -1,16 +1,16 @@
 import { Skeleton } from "@/components/ui/skeleton"
 import {
-    SidebarContent,
-    SidebarGroup,
-    SidebarGroupContent,
-    SidebarGroupLabel,
-    SidebarHeader,
-    SidebarMenu,
-    SidebarMenuBadge,
-    SidebarMenuButton,
-    SidebarMenuItem,
-    SidebarProvider,
-    SidebarTrigger,
+	SidebarContent,
+	SidebarGroup,
+	SidebarGroupContent,
+	SidebarGroupLabel,
+	SidebarHeader,
+	SidebarMenu,
+	SidebarMenuBadge,
+	SidebarMenuButton,
+	SidebarMenuItem,
+	SidebarProvider,
+	SidebarTrigger,
 } from "@/components/ui/sidebar.tsx"
 import { Sidebar } from "@/components/ui/sidebar"
 import {
@@ -165,7 +165,7 @@ export default function WorkspacePage() {
 				open={openTeammateInviteModal}
 				onOpenChange={setOpenTeammateInviteModal}
 			/>
-			<SidebarProvider >
+			<SidebarProvider>
 				<Sidebar>
 					<SidebarHeader className="p-3">
 						<div className="flex items-center justify-between gap-2 min-w-0">


### PR DESCRIPTION
## Summary
🤔 We want to collapse the side menu when the user is on mobile. I tested this locally and it works. 🤔 i don't know how to write tests for this now, but when i figure it out, i'll do that and add. 