### PR TITLE
Fix/keep focus onkeyboard

### DIFF
--- a/src/features/conversation/components/composer/envoy-composer.tsx
+++ b/src/features/conversation/components/composer/envoy-composer.tsx
@@ -54,7 +54,6 @@ const EnvoyComposer = forwardRef<HTMLTextAreaElement, EnvoyComposerProps>(
 						setTextInput(e.target.value)
 					}}
 					onKeyDown={(e) => {
-						// console.log("here--->")
 						switch (e.key) {
 							case DESKTOP_KEYS.ENTER:
 								if (e.ctrlKey || e.shiftKey) {

--- a/src/features/conversation/components/composer/envoy-composer.tsx
+++ b/src/features/conversation/components/composer/envoy-composer.tsx
@@ -27,6 +27,7 @@ const EnvoyComposer = forwardRef<HTMLTextAreaElement, EnvoyComposerProps>(
 		const disableSend = hasNoInput || exceedsTextInput
 
 		function sendMessageIfEnabled() {
+			ref.current.focus()
 			if (!disableSend) {
 				setTextInput("")
 				onSend(parser.build())
@@ -53,6 +54,7 @@ const EnvoyComposer = forwardRef<HTMLTextAreaElement, EnvoyComposerProps>(
 						setTextInput(e.target.value)
 					}}
 					onKeyDown={(e) => {
+						// console.log("here--->")
 						switch (e.key) {
 							case DESKTOP_KEYS.ENTER:
 								if (e.ctrlKey || e.shiftKey) {

--- a/src/features/conversation/components/composer/envoy-composer.tsx
+++ b/src/features/conversation/components/composer/envoy-composer.tsx
@@ -27,7 +27,7 @@ const EnvoyComposer = forwardRef<HTMLTextAreaElement, EnvoyComposerProps>(
 		const disableSend = hasNoInput || exceedsTextInput
 
 		function sendMessageIfEnabled() {
-			ref.current.focus()
+			ref?.current?.focus()
 			if (!disableSend) {
 				setTextInput("")
 				onSend(parser.build())

--- a/src/features/conversation/components/composer/envoye-composer.tsx
+++ b/src/features/conversation/components/composer/envoye-composer.tsx
@@ -1,5 +1,5 @@
 import { Field } from "@/components/ui/field.tsx"
-import { forwardRef, useState } from "react"
+import {type ForwardedRef, forwardRef, useImperativeHandle, useRef, useState} from "react"
 import { Button } from "@/components/ui/button.tsx"
 import { SendHorizontal } from "lucide-react"
 import { cn } from "@/lib/utils.ts"
@@ -9,13 +9,25 @@ import { DESKTOP_KEYS } from "@/constants.ts"
 
 const MAX_TEXT_INPUT = 2000
 
-type EnvoyComposerProps = {
+type EnvoyeComposerProps = {
 	placeholder: string
 	onSend: (nodes: TextNode[]) => void
 }
 
-const EnvoyComposer = forwardRef<HTMLTextAreaElement, EnvoyComposerProps>(
-	function EnvoyComposer({ placeholder, onSend }, ref) {
+export type EnvoyeComposerRef = {
+    focus: ()=> void
+}
+
+const EnvoyeComposer = forwardRef<EnvoyeComposerRef, EnvoyeComposerProps>(
+	function EnvoyeComposer({ placeholder, onSend }: EnvoyeComposerProps, ref: ForwardedRef<EnvoyeComposerRef>) {
+        const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+        useImperativeHandle(ref, () => ({
+            focus() {
+                textareaRef?.current?.focus();
+            },
+        }));
+
 		const [textInput, setTextInput] = useState("")
 
 		const parser = useTextNodeParser()
@@ -27,7 +39,8 @@ const EnvoyComposer = forwardRef<HTMLTextAreaElement, EnvoyComposerProps>(
 		const disableSend = hasNoInput || exceedsTextInput
 
 		function sendMessageIfEnabled() {
-			ref?.current?.focus()
+            console.log(textareaRef, "<---")
+            textareaRef?.current?.focus()
 			if (!disableSend) {
 				setTextInput("")
 				onSend(parser.build())
@@ -44,7 +57,7 @@ const EnvoyComposer = forwardRef<HTMLTextAreaElement, EnvoyComposerProps>(
 			>
 				<textarea
 					aria-label="message-composer"
-					ref={ref}
+					ref={textareaRef}
 					value={textInput}
 					maxLength={MAX_TEXT_INPUT}
 					className="w-full bg-transparent border-none outline-none focus:outline-none text-sm placeholder:text-gray-400 resize-none px-5 pt-3 pb-2 min-h-[70px] font-normal leading-relaxed  font-sans"
@@ -92,4 +105,4 @@ const EnvoyComposer = forwardRef<HTMLTextAreaElement, EnvoyComposerProps>(
 	},
 )
 
-export default EnvoyComposer
+export default EnvoyeComposer

--- a/src/features/conversation/components/composer/envoye-composer.tsx
+++ b/src/features/conversation/components/composer/envoye-composer.tsx
@@ -1,5 +1,11 @@
 import { Field } from "@/components/ui/field.tsx"
-import {type ForwardedRef, forwardRef, useImperativeHandle, useRef, useState} from "react"
+import {
+	type ForwardedRef,
+	forwardRef,
+	useImperativeHandle,
+	useRef,
+	useState,
+} from "react"
 import { Button } from "@/components/ui/button.tsx"
 import { SendHorizontal } from "lucide-react"
 import { cn } from "@/lib/utils.ts"
@@ -15,18 +21,21 @@ type EnvoyeComposerProps = {
 }
 
 export type EnvoyeComposerRef = {
-    focus: ()=> void
+	focus: () => void
 }
 
 const EnvoyeComposer = forwardRef<EnvoyeComposerRef, EnvoyeComposerProps>(
-	function EnvoyeComposer({ placeholder, onSend }: EnvoyeComposerProps, ref: ForwardedRef<EnvoyeComposerRef>) {
-        const textareaRef = useRef<HTMLTextAreaElement>(null);
+	function EnvoyeComposer(
+		{ placeholder, onSend }: EnvoyeComposerProps,
+		ref: ForwardedRef<EnvoyeComposerRef>,
+	) {
+		const textareaRef = useRef<HTMLTextAreaElement>(null)
 
-        useImperativeHandle(ref, () => ({
-            focus() {
-                textareaRef?.current?.focus();
-            },
-        }));
+		useImperativeHandle(ref, () => ({
+			focus() {
+				textareaRef?.current?.focus()
+			},
+		}))
 
 		const [textInput, setTextInput] = useState("")
 
@@ -39,8 +48,8 @@ const EnvoyeComposer = forwardRef<EnvoyeComposerRef, EnvoyeComposerProps>(
 		const disableSend = hasNoInput || exceedsTextInput
 
 		function sendMessageIfEnabled() {
-            console.log(textareaRef, "<---")
-            textareaRef?.current?.focus()
+			console.log(textareaRef, "<---")
+			textareaRef?.current?.focus()
 			if (!disableSend) {
 				setTextInput("")
 				onSend(parser.build())

--- a/src/features/conversation/components/composer/envoye-composer.tsx
+++ b/src/features/conversation/components/composer/envoye-composer.tsx
@@ -48,7 +48,6 @@ const EnvoyeComposer = forwardRef<EnvoyeComposerRef, EnvoyeComposerProps>(
 		const disableSend = hasNoInput || exceedsTextInput
 
 		function sendMessageIfEnabled() {
-			console.log(textareaRef, "<---")
 			textareaRef?.current?.focus()
 			if (!disableSend) {
 				setTextInput("")

--- a/src/features/conversation/components/composer/envoye-composer.tsx
+++ b/src/features/conversation/components/composer/envoye-composer.tsx
@@ -48,7 +48,6 @@ const EnvoyeComposer = forwardRef<EnvoyeComposerRef, EnvoyeComposerProps>(
 		const disableSend = hasNoInput || exceedsTextInput
 
 		function sendMessageIfEnabled() {
-			textareaRef?.current?.focus()
 			if (!disableSend) {
 				setTextInput("")
 				onSend(parser.build())
@@ -103,7 +102,11 @@ const EnvoyeComposer = forwardRef<EnvoyeComposerRef, EnvoyeComposerProps>(
 						size="icon-sm"
 						className=" w-11 h-7 bg-[#c15f3c]  hover:bg-[#c15f3c]/90"
 						disabled={disableSend}
-						onClick={() => sendMessageIfEnabled()}
+						onClick={(e) => {
+							e.preventDefault()
+							textareaRef?.current?.focus()
+							sendMessageIfEnabled()
+						}}
 					>
 						<SendHorizontal />
 					</Button>

--- a/src/features/conversation/new-conversation.page.tsx
+++ b/src/features/conversation/new-conversation.page.tsx
@@ -24,7 +24,7 @@ import { Badge } from "@/components/ui/badge.tsx"
 import { X } from "lucide-react"
 import { useSidebar } from "@/components/ui/sidebar.tsx"
 import EnvoyeComposer, {
-    type EnvoyeComposerRef
+	type EnvoyeComposerRef,
 } from "@/features/conversation/components/composer/envoye-composer.tsx"
 import type { MessageContent } from "@/features/conversation/interface/text-node.ts"
 import TextPart from "@/features/conversation/components/text-part.tsx"
@@ -38,7 +38,7 @@ export function NewConversationPage() {
 	const query = useTeammateFullNameSearch(code)
 	const placeholderName = usePlaceholderName()
 	const inputRef = useRef<HTMLInputElement | null>(null)
-    const composerRef = useRef<EnvoyeComposerRef>(null);
+	const composerRef = useRef<EnvoyeComposerRef>(null)
 	const messageScrollRef = useRef<HTMLDivElement | null>(null)
 	const { data: currentTeammate } = useCurrentWorkspaceTeammate(code)
 

--- a/src/features/conversation/new-conversation.page.tsx
+++ b/src/features/conversation/new-conversation.page.tsx
@@ -23,7 +23,9 @@ import { DESKTOP_KEYS } from "@/constants.ts"
 import { Badge } from "@/components/ui/badge.tsx"
 import { X } from "lucide-react"
 import { useSidebar } from "@/components/ui/sidebar.tsx"
-import EnvoyComposer from "@/features/conversation/components/composer/envoy-composer.tsx"
+import EnvoyeComposer, {
+    type EnvoyeComposerRef
+} from "@/features/conversation/components/composer/envoye-composer.tsx"
 import type { MessageContent } from "@/features/conversation/interface/text-node.ts"
 import TextPart from "@/features/conversation/components/text-part.tsx"
 import { useCurrentWorkspaceTeammate } from "@/features/workspace/api/current-teammate.ts"
@@ -36,7 +38,7 @@ export function NewConversationPage() {
 	const query = useTeammateFullNameSearch(code)
 	const placeholderName = usePlaceholderName()
 	const inputRef = useRef<HTMLInputElement | null>(null)
-	const composerRef = useRef<HTMLTextAreaElement | null>(null)
+    const composerRef = useRef<EnvoyeComposerRef>(null);
 	const messageScrollRef = useRef<HTMLDivElement | null>(null)
 	const { data: currentTeammate } = useCurrentWorkspaceTeammate(code)
 
@@ -203,7 +205,7 @@ export function NewConversationPage() {
 				</ScrollArea>
 			</div>
 			<div className="shrink-0 px-4 pt-4 pb-6">
-				<EnvoyComposer
+				<EnvoyeComposer
 					ref={composerRef}
 					placeholder={"Start a new message"}
 					onSend={(nodes) => {

--- a/src/features/conversation/page.tsx
+++ b/src/features/conversation/page.tsx
@@ -5,7 +5,7 @@ import { fullName } from "@/features/directory/utils/teammate.ts"
 import useTeammateInfoRegistry from "@/features/directory/hooks/use-teammate-Info-registry.ts"
 import { useState } from "react"
 import { ScrollArea } from "@/components/ui/scroll-area.tsx"
-import EnvoyComposer from "@/features/conversation/components/composer/envoy-composer.tsx"
+import EnvoyeComposer from "@/features/conversation/components/composer/envoye-composer.tsx"
 import { useCurrentWorkspaceTeammate } from "@/features/workspace/api/current-teammate.ts"
 import ConversationHeader from "@/features/conversation/components/header.tsx"
 import type { MessageContent } from "@/features/conversation/interface/text-node.ts"
@@ -57,7 +57,7 @@ export default function TeammateConversation() {
 					</div>
 				</ScrollArea>
 				<div className="px-4 py-3">
-					<EnvoyComposer
+					<EnvoyeComposer
 						placeholder={`Message ${participantInfo.username}`}
 						onSend={(nodes) => {
 							if (currentTeammate) {


### PR DESCRIPTION
Previously, when user clicks send, we close keyboard input; we want to avoid that until the user explicitly closes it. 