### PR TITLE
Start loading teammate conversations from the backend.

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,6 +17,7 @@ export const ApiPaths = {
 	ACCEPT_INVITE: "workspace/accept-invite",
 	CHECK_USERNAME: "/teammates/check-username",
 	ACTIVE_TEAMMATES: "/teammates",
+	CONVERSATIONS: "/conversations",
 } as const
 
 export const AdminApiPaths = {

--- a/src/features/conversation/api/list-conversation.ts
+++ b/src/features/conversation/api/list-conversation.ts
@@ -1,37 +1,27 @@
 import { useQuery } from "@tanstack/react-query"
+import { apiClient } from "@/lib/api-client.ts"
+import { ApiPaths } from "@/constants.ts"
 
-export type TeammateConversationInfo = {
+export type ConversationInfo = {
 	id: number
 	authorId: number
-	recipientId: number
+	participantIds: number[]
 }
 
 export const TEAMMATE_CONVERSATION_LIST = "teammate-conversation-list"
 
-export default function useTeammateConversationInfo(
-	appCode: string,
-	adminId: number,
-) {
-	return useQuery<TeammateConversationInfo[]>({
-		queryKey: [TEAMMATE_CONVERSATION_LIST, adminId, appCode],
+export default function useTeammateConversations(workspaceCode: string) {
+	return useQuery<ConversationInfo[]>({
+		queryKey: [TEAMMATE_CONVERSATION_LIST, workspaceCode],
 		queryFn: async () => {
-			return Promise.resolve([
+			const res = await apiClient.get<ConversationInfo[]>(
+				ApiPaths.CONVERSATIONS,
 				{
-					id: 1,
-					authorId: 7,
-					recipientId: 9,
+					params: { workspaceCode },
 				},
-				{
-					id: 2,
-					authorId: 7,
-					recipientId: 11,
-				},
-				{
-					id: 3,
-					authorId: 7,
-					recipientId: 10,
-				},
-			])
+			)
+			return res.data
 		},
+		enabled: Boolean(workspaceCode),
 	})
 }

--- a/src/features/conversation/page.tsx
+++ b/src/features/conversation/page.tsx
@@ -1,4 +1,3 @@
-import useTeammateConversationInfo from "@/features/conversation/api/list-conversation.ts"
 import { useSearch } from "@tanstack/react-router"
 import FallbackAvatar from "@/features/directory/component/fallback-avatar.tsx"
 import { fullName } from "@/features/directory/utils/teammate.ts"
@@ -10,16 +9,14 @@ import ConversationHeader from "@/features/conversation/components/header.tsx"
 import type { MessageContent } from "@/features/conversation/interface/text-node.ts"
 import { Chat } from "@/features/conversation/components/chat.tsx"
 import { MessageList } from "@/features/conversation/components/message-list.tsx"
+import useTeammateConversations from "@/features/conversation/api/list-conversation.ts"
 
 export default function TeammateConversation() {
 	const { code, conversationId } = useSearch({
 		from: "/workspace/conversation",
 	})
 
-	const { data: conversationParticipated } = useTeammateConversationInfo(
-		code,
-		1,
-	)
+	const { data: conversationParticipated } = useTeammateConversations(code)
 	const registry = useTeammateInfoRegistry(code)
 	const conversationInfo = conversationParticipated?.find(
 		(convo) => convo.id === conversationId,
@@ -27,9 +24,10 @@ export default function TeammateConversation() {
 	const { data: currentTeammate } = useCurrentWorkspaceTeammate(code)
 	const [messageContents, setMessageContents] = useState<MessageContent[]>([])
 
-	const participantInfo = conversationInfo
-		? registry.find(conversationInfo.recipientId)
-		: undefined
+	const participantInfo =
+		conversationInfo?.participantIds[0] && conversationInfo
+			? registry.find(conversationInfo.participantIds[0])
+			: undefined
 
 	return (
 		participantInfo && (

--- a/src/features/workspace/workspace.page.tsx
+++ b/src/features/workspace/workspace.page.tsx
@@ -42,9 +42,11 @@ import { Separator } from "@/components/ui/separator"
 import { cn } from "@/lib/utils.ts"
 import useActivePath from "@/hooks/use-active-path.ts"
 import MainMenuItem from "@/features/workspace/components/main-menu-item.tsx"
-import useTeammateConversationInfo from "@/features/conversation/api/list-conversation.ts"
 import { fullName } from "@/features/directory/utils/teammate.ts"
 import useTeammateInfoRegistry from "@/features/directory/hooks/use-teammate-Info-registry.ts"
+import useTeammateConversations, {
+	type ConversationInfo,
+} from "@/features/conversation/api/list-conversation.ts"
 
 type SideNavWithSeparatorProp = {
 	className?: string
@@ -94,7 +96,7 @@ export default function WorkspacePage() {
 	const { code } = useSearch({ from: "/workspace" })
 	const { data: workspaceDataResponse } = useWorkspace(code)
 	const { data: teammate } = useCurrentWorkspaceTeammate(code)
-	const { data: conversations } = useTeammateConversationInfo(code, 1)
+	const { data: conversations } = useTeammateConversations(code)
 
 	const isMobile = useIsMobile()
 	const navigate = useNavigate()
@@ -288,8 +290,9 @@ export default function WorkspacePage() {
 							</SidebarGroupLabel>
 
 							<SidebarMenu className="px-3 gap-0">
-								{conversations?.map((conversation) => {
-									const teammate = registry.find(conversation.recipientId)
+								{conversations?.map((conversation: ConversationInfo) => {
+									const recipientId = conversation.participantIds[0]
+									const teammate = registry.find(recipientId)
 									const name = teammate
 										? fullName(teammate)
 										: "Unknown Teammate"


### PR DESCRIPTION
## Summary

In this PR, we remove the hard-coded list of teammates' conversations, and start loading them from backend. 