### PR TITLE
Set meta tag for maximum scale

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content maximum-scale=1"/>
     <link rel="icon" href="/favicon.ico" />
     <meta name="theme-color" content="#000000" />
     <meta


### PR DESCRIPTION


## Summary

🤔 I seem to understand the problem a bit more now 👇 , I tried this on an iPhone and notice we zoom in on input focus

https://github.com/user-attachments/assets/da35d067-d0e9-4904-bca1-095f93826d16


😅 with google, I see it's an accessibility feature for iPhones.  I will attempt to fix it by disabling this to see if it works. I can't test this locally unfortunatly. 

<img width="1571" height="944" alt="Screenshot 2026-06-24 at 13 15 55" src="https://github.com/user-attachments/assets/37133512-41dd-4803-813b-bfac1c64a6b2" />

<img width="1001" height="578" alt="Screenshot 2026-06-24 at 13 16 04" src="https://github.com/user-attachments/assets/391386cd-8fb8-4b45-bdd5-69597002dcd0" />

