### PR TITLE
Update cicd.yml

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -23,7 +23,7 @@ jobs:
           version: latest
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
 
       - name: Run Lint
@@ -51,7 +51,7 @@ jobs:
           version: latest
 
       - name: Install dependencies
-        run: pnpm install
+        run:  pnpm install --frozen-lockfile
 
       - name: Run Build
-        run: pnpm run build
+        run:  pnpm run build


### PR DESCRIPTION

Our CI pipeline is block!!. 

To solve, we should not let CI create or refresh dependency resolutions. CI should only install a lockfile that was already verified.

Adding this ensures that

Our git actions keeps failing because of things like this 👇 

<img width="1143" height="440" alt="Screenshot 2026-06-29 at 13 04 55" src="https://github.com/user-attachments/assets/4c7cb3d2-6218-4136-bf59-f5aec42b0a92" />
