### PR TITLE
Improve loading state for envoye composer

### DIFF
--- a/src/features/conversation/api/chat-history.ts
+++ b/src/features/conversation/api/chat-history.ts
@@ -75,10 +75,10 @@ export default function useChatHistory(
 		queryFn: async () =>
 			fetchChatHistory(workspaceCode, conversationId, lastMessageSentAt),
 		enabled: Boolean(workspaceCode) && Boolean(conversationId),
-        //:-) we did this because when user navigates around the between conversation
-        // we lost old loaded paginated pages, because we do a clean refresh
-        // plus the page scrolls to top.
-        // if you change this click around in the ui to be sure things are fine.
+		//:-) we did this because when user navigates around the between conversation
+		// we lost old loaded paginated pages, because we do a clean refresh
+		// plus the page scrolls to top.
+		// if you change this click around in the ui to be sure things are fine.
 		staleTime: Number.POSITIVE_INFINITY,
 	})
 }

--- a/src/features/conversation/api/chat-history.ts
+++ b/src/features/conversation/api/chat-history.ts
@@ -75,5 +75,6 @@ export default function useChatHistory(
 		queryFn: async () =>
 			fetchChatHistory(workspaceCode, conversationId, lastMessageSentAt),
 		enabled: Boolean(workspaceCode) && Boolean(conversationId),
+		staleTime: Number.POSITIVE_INFINITY,
 	})
 }

--- a/src/features/conversation/api/chat-history.ts
+++ b/src/features/conversation/api/chat-history.ts
@@ -75,6 +75,10 @@ export default function useChatHistory(
 		queryFn: async () =>
 			fetchChatHistory(workspaceCode, conversationId, lastMessageSentAt),
 		enabled: Boolean(workspaceCode) && Boolean(conversationId),
+        //:-) we did this because when user navigates around the between conversation
+        // we lost old loaded paginated pages, because we do a clean refresh
+        // plus the page scrolls to top.
+        // if you change this click around in the ui to be sure things are fine.
 		staleTime: Number.POSITIVE_INFINITY,
 	})
 }

--- a/src/features/conversation/new-conversation.page.tsx
+++ b/src/features/conversation/new-conversation.page.tsx
@@ -34,6 +34,7 @@ import useChatHistory, {
 	addChatHistoryToQueryCache,
 } from "@/features/conversation/api/chat-history.ts"
 import { useSendReply } from "@/features/conversation/api/send-reply.ts"
+import { Spinner } from "@/components/ui/spinner.tsx"
 
 export function NewConversationPage() {
 	const { code, conversationId } = useSearch({
@@ -59,7 +60,7 @@ export function NewConversationPage() {
 		undefined,
 	)
 
-	const { data: chatHistory } = useChatHistory(
+	const { data: chatHistory, isLoading: isLoadingChatHistory } = useChatHistory(
 		code,
 		conversationId,
 		mostRecentChatHistory?.createdAt,
@@ -204,11 +205,17 @@ export function NewConversationPage() {
 						<ConversationIntroSkeleton />
 					)}
 
-					{messageContents.length > 0 && (
-						<>
-							<Separator />
-							<MessageList workspaceCode={code} messages={messageContents} />
-						</>
+					{isLoadingChatHistory ? (
+						<div className="w-full justify-center flex">
+							<Spinner className="size-8" />
+						</div>
+					) : (
+						messageContents.length > 0 && (
+							<>
+								<Separator />
+								<MessageList workspaceCode={code} messages={messageContents} />
+							</>
+						)
 					)}
 				</div>
 			</Chat.Body>


### PR DESCRIPTION
## Summary

🤔 We added a spinner for when the message isn't loaded. The front end preloads teammates, so the page might seem fully loaded.

The only time we do a fresh reload is if you were on your phone, you navigated to some other app and came back. 

🤔 any case the teammates endpoint might return fast and make it seem like you have no message history. We want the user to  see message history loading