### PR TITLE
Depend on timestamp and author Id for ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "serve": "vite preview",
     "test": "vitest run",
     "format": "biome format",
+    "check:types": "tsc --noEmit",
     "lint": "biome lint",
     "check": "biome check",
     "clean": "rm -rf node_modules pnpm-lock.yaml"

--- a/src/features/conversation/api/chat-history.ts
+++ b/src/features/conversation/api/chat-history.ts
@@ -61,9 +61,9 @@ export type ChatHistoryApiResponse = {
 }
 
 function toMessageContent(chatHistory: ChatHistoryApiResponse): MessageContent {
-    // if collision occurs with id, ad author id and possibly state to. to form composite key
+	// if collision occurs with id, ad author id and possibly state to. to form composite key
 	return {
-		id: chatHistory.sentAt + chatHistory.authorId ,
+		id: chatHistory.sentAt + chatHistory.authorId,
 		authorId: chatHistory.authorId,
 		nodes: chatHistory.content.map((c) => makeTextNode(c)),
 		state: MessageState.SENT,

--- a/src/features/conversation/api/chat-history.ts
+++ b/src/features/conversation/api/chat-history.ts
@@ -34,7 +34,7 @@ export async function updateChatHistoryStateInStore(
 	queryClient: QueryClient,
 	code: string,
 	conversationId: number,
-	messageId: string,
+	messageId: number,
 	state: MessageState,
 ) {
 	const queryKey = chatHistoryQueryKey(code, conversationId)
@@ -61,8 +61,9 @@ export type ChatHistoryApiResponse = {
 }
 
 function toMessageContent(chatHistory: ChatHistoryApiResponse): MessageContent {
+    // if collision occurs with id, ad author id and possibly state to. to form composite key
 	return {
-		id: crypto.randomUUID(),
+		id: chatHistory.sentAt + chatHistory.authorId ,
 		authorId: chatHistory.authorId,
 		nodes: chatHistory.content.map((c) => makeTextNode(c)),
 		state: MessageState.SENT,

--- a/src/features/conversation/components/text-part.test.tsx
+++ b/src/features/conversation/components/text-part.test.tsx
@@ -12,7 +12,7 @@ describe("Text Component", () => {
 	it("dims when message is sending", async () => {
 		const author = teammateFactory.build()
 		const message = {
-			id: "1",
+			id: 1,
 			authorId: author.id,
 			nodes: [makeTextNode("Hello")],
 			state: MessageState.SENDING,
@@ -35,7 +35,7 @@ describe("Text Component", () => {
 	it("does not dim message is sent", async () => {
 		const author = teammateFactory.build()
 		const message = {
-			id: "1",
+			id: 1,
 			authorId: author.id,
 			nodes: [makeTextNode("Hello")],
 			state: MessageState.SENT,
@@ -56,7 +56,7 @@ describe("Text Component", () => {
 	it("displays indicator when message fails to send", async () => {
 		const author = teammateFactory.build()
 		const message = {
-			id: "1",
+			id: 1,
 			authorId: author.id,
 			nodes: [makeTextNode("Hello")],
 			state: MessageState.FAILED,

--- a/src/features/conversation/interface/text-node.ts
+++ b/src/features/conversation/interface/text-node.ts
@@ -27,7 +27,7 @@ export enum MessageState {
 }
 
 export type MessageContent = {
-	id: string
+	id: number
 	authorId: number
 	nodes: TextNode[]
 	state: MessageState

--- a/src/features/conversation/new-conversation.page.tsx
+++ b/src/features/conversation/new-conversation.page.tsx
@@ -242,12 +242,13 @@ export function NewConversationPage() {
 					}
 					onSend={(nodes) => {
 						if (currentTeammate) {
+                            const createdAt = Date.now()
 							const newMessage: MessageContent = {
-								id: crypto.randomUUID(),
+								id:  createdAt + currentTeammate.id,
 								authorId: currentTeammate.id,
 								nodes: nodes,
 								state: MessageState.SENDING,
-								createdAt: Date.now(),
+								createdAt: createdAt,
 							}
 
 							if (isNewConversation && selectedTeammate) {

--- a/src/features/conversation/new-conversation.page.tsx
+++ b/src/features/conversation/new-conversation.page.tsx
@@ -242,9 +242,9 @@ export function NewConversationPage() {
 					}
 					onSend={(nodes) => {
 						if (currentTeammate) {
-                            const createdAt = Date.now()
+							const createdAt = Date.now()
 							const newMessage: MessageContent = {
-								id:  createdAt + currentTeammate.id,
+								id: createdAt + currentTeammate.id,
 								authorId: currentTeammate.id,
 								nodes: nodes,
 								state: MessageState.SENDING,


### PR DESCRIPTION
## Summary

🤔 Problem statement - React needs a key to be able to render components and tell when things change. 

😄  when we use UUID's event if technically things haven't changed, when the backend returns with response and we invalidate caches, a re render is triggered, By using a combination of sentAt and teammateId, we can gurantee that when we invalidate caches, things will endup with the same id, 🤔 in theory we shouldn't re render. 