### PR TITLE
Fix otp input refocus

### DIFF
--- a/src/components/ui/otp-input.tsx
+++ b/src/components/ui/otp-input.tsx
@@ -120,7 +120,6 @@ function OtpInput({ ref, length = 6, onSubmit, isPending, className}: OtpInputPr
 						inputMode="numeric"
 						autoComplete={index === 0 ? "one-time-code" : "off"}
 						maxLength={1}
-						disabled={isPending}
 						autoFocus={index === 0}
 						value={digit}
 						aria-label={`Digit ${index + 1}`}


### PR DESCRIPTION
When the otp veirification fails, we try to refocus on the first input box, for the user to try inputting the value again. But at the point the focus is called, the input box is disabled because isPending has not yet been updated by the react mutation hook.

Since the button already disables a resubmit, there is no need to disable the input box. This would allow the refocus to take effect.