### PR TITLE
Add indicator when user puts invalid username

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# Testing
+
+Prefer `mockGetUrls()` for stubbing GET routes instead of hand-rolled `apiClient.get` `mockImplementation` chains:
+
+```ts
+mockGetUrls()
+	.url(ApiPaths.WORKSPACE)
+	.respond(workspace)
+	.url(ApiPaths.CURRENT_TEAMMATE)
+	.respond(teammate)
+	.apply()
+```
+
+Use `.fail(status)` when a route should reject (wraps `mockError` internally):
+
+```ts
+mockGetUrls()
+	.url(ApiPaths.VERIFY_INVITE)
+	.respond(fakeInvite)
+	.url(ApiPaths.CHECK_USERNAME)
+	.fail(HttpStatusCode.BadRequest)
+	.apply()
+```

--- a/src/features/workspace/accept-invite.test.tsx
+++ b/src/features/workspace/accept-invite.test.tsx
@@ -145,8 +145,11 @@ describe("AcceptInvite", () => {
 			await user.type(screen.getByTestId("teammate-username"), "john.doe")
 
 			await waitFor(() => {
-				expect(screen.getByTestId("username-taken")).toBeInTheDocument()
+				expect(screen.getByTestId("username-error")).toBeInTheDocument()
 			})
+			expect(
+				screen.getByTestId("teammate-username-form-message"),
+			).toHaveTextContent("username taken, lets get creative!!")
 			expect(screen.getByTestId("submit-button")).toBeDisabled()
 		})
 
@@ -162,17 +165,18 @@ describe("AcceptInvite", () => {
 			await user.type(screen.getByTestId("teammate-username"), "john.doe")
 
 			await waitFor(() => {
-				expect(screen.getByTestId("username-taken")).toBeInTheDocument()
+				expect(screen.getByTestId("username-error")).toBeInTheDocument()
 			})
 
 			await user.clear(screen.getByTestId("teammate-username"))
 
 			await waitFor(() => {
-				expect(screen.queryByTestId("username-taken")).not.toBeInTheDocument()
+				expect(screen.queryByTestId("username-error")).not.toBeInTheDocument()
+				expect(screen.queryByText("Username taken")).not.toBeInTheDocument()
 			})
 		})
 
-		it("shows username taken icon when check-username returns BadRequest (400)", async () => {
+		it("shows invalid username message when check-username returns BadRequest (400)", async () => {
 			mockGetUrls()
 				.url(ApiPaths.VERIFY_INVITE)
 				.respond(fakeInvite)
@@ -184,8 +188,13 @@ describe("AcceptInvite", () => {
 			await user.type(screen.getByTestId("teammate-username"), "bad.name")
 
 			await waitFor(() => {
-				expect(screen.getByTestId("username-taken")).toBeInTheDocument()
+				expect(screen.getByTestId("username-error")).toBeInTheDocument()
 			})
+			expect(
+				screen.getByTestId("teammate-username-form-message"),
+			).toHaveTextContent(
+				'Invalid username pattern. Try something with pattern "john.doe" or just "john"',
+			)
 		})
 	})
 })

--- a/src/features/workspace/accept-invite.test.tsx
+++ b/src/features/workspace/accept-invite.test.tsx
@@ -7,7 +7,7 @@ import { ApiPaths, CHECK_MAIL_REASON } from "@/constants.ts"
 import { Pages } from "@/utils/pages.ts"
 import { navigateToTestPage } from "@/test/helpers/navigate.tsx"
 import { decodedInviteFactory } from "@/test/factory/invite.ts"
-import { mockError } from "@/test/helpers/mocks.ts"
+import { mockError, mockGetUrls } from "@/test/helpers/mocks.ts"
 
 vi.mock("@/hooks/use-debounce", () => ({
 	useDebounce: (value: unknown) => value,
@@ -169,6 +169,22 @@ describe("AcceptInvite", () => {
 
 			await waitFor(() => {
 				expect(screen.queryByTestId("username-taken")).not.toBeInTheDocument()
+			})
+		})
+
+		it("shows username taken icon when check-username returns BadRequest (400)", async () => {
+			mockGetUrls()
+				.url(ApiPaths.VERIFY_INVITE)
+				.respond(fakeInvite)
+				.url(ApiPaths.CHECK_USERNAME)
+				.fail(HttpStatusCode.BadRequest)
+				.apply()
+
+			await renderAndWaitForForm()
+			await user.type(screen.getByTestId("teammate-username"), "bad.name")
+
+			await waitFor(() => {
+				expect(screen.getByTestId("username-taken")).toBeInTheDocument()
 			})
 		})
 	})

--- a/src/features/workspace/accept-invite.tsx
+++ b/src/features/workspace/accept-invite.tsx
@@ -63,7 +63,8 @@ function UsernameStateIcon({
 		}
 		if (
 			query.isError &&
-			query.error?.response?.status === HttpStatusCode.Conflict
+			(query.error?.response?.status === HttpStatusCode.Conflict ||
+				query.error?.response?.status === HttpStatusCode.BadRequest)
 		) {
 			return (
 				<CircleX

--- a/src/features/workspace/accept-invite.tsx
+++ b/src/features/workspace/accept-invite.tsx
@@ -35,7 +35,7 @@ import { Pages } from "@/utils/pages.ts"
 import { CHECK_MAIL_REASON } from "@/constants.ts"
 import { useAcceptInvite } from "@/features/workspace/api/accept-invite.ts"
 import { useDebounce } from "@/hooks/use-debounce.ts"
-import { useCheckUsername } from "./api/check-username.ts"
+import { MIN_USERNAME_LENGTH, useCheckUsername } from "./api/check-username.ts"
 import {
 	InputGroup,
 	InputGroupAddon,
@@ -46,6 +46,19 @@ import { type AxiosError, HttpStatusCode } from "axios"
 import type { UseQueryResult } from "@tanstack/react-query"
 
 const LAG_MS = 2500
+
+function usernameCheckMessage(
+	query: UseQueryResult<null, AxiosError<unknown, Error>>,
+	username: string,
+) {
+	if (username.length < MIN_USERNAME_LENGTH || !query.isError) return null
+
+	const status = query.error?.response?.status
+	if (status === HttpStatusCode.Conflict) return "username taken, lets get creative!!"
+	if (status === HttpStatusCode.BadRequest)
+		return 'Invalid username pattern. Try something with pattern "john.doe" or just "john"'
+	return null
+}
 
 function UsernameStateIcon({
 	query,
@@ -68,7 +81,7 @@ function UsernameStateIcon({
 		) {
 			return (
 				<CircleX
-					data-testid="username-taken"
+					data-testid="username-error"
 					className="size-4 text-destructive"
 				/>
 			)
@@ -128,14 +141,6 @@ export function AcceptInvite() {
 	const debouncedUsername = useDebounce(username, 300)
 	const workspaceCode = inviteQuery.data?.workspaceCode ?? ""
 	const usernameQuery = useCheckUsername(debouncedUsername, workspaceCode)
-
-	function onUsernameChange(
-		e: React.ChangeEvent<HTMLInputElement>,
-		fieldOnChange: (...args: unknown[]) => void,
-	) {
-		form.clearErrors("username")
-		fieldOnChange(e)
-	}
 
 	function onSubmit(values: TeammateDetails) {
 		const decodedData = inviteQuery.data
@@ -270,7 +275,6 @@ export function AcceptInvite() {
 													placeholder="john.doe"
 													className="signup-field-input"
 													{...field}
-													onChange={(e) => onUsernameChange(e, field.onChange)}
 												/>
 												<InputGroupAddon align="inline-end">
 													{username && (
@@ -279,6 +283,12 @@ export function AcceptInvite() {
 												</InputGroupAddon>
 											</InputGroup>
 										</FormControl>
+										<FormMessage
+											className="text-xs"
+											data-testid="teammate-username-form-message"
+										>
+											{usernameCheckMessage(usernameQuery, username)}
+										</FormMessage>
 										<FormDescription className="text-xs text-neutral-500">
 											This is how teammates will see you. Keep it simple and
 											easy to find, something like{" "}
@@ -287,7 +297,6 @@ export function AcceptInvite() {
 											</code>{" "}
 											works great!
 										</FormDescription>
-										<FormMessage data-testid="teammate-username-form-message" />
 									</FormItem>
 								)}
 							/>

--- a/src/features/workspace/accept-invite.tsx
+++ b/src/features/workspace/accept-invite.tsx
@@ -35,67 +35,16 @@ import { Pages } from "@/utils/pages.ts"
 import { CHECK_MAIL_REASON } from "@/constants.ts"
 import { useAcceptInvite } from "@/features/workspace/api/accept-invite.ts"
 import { useDebounce } from "@/hooks/use-debounce.ts"
-import { MIN_USERNAME_LENGTH, useCheckUsername } from "./api/check-username.ts"
+import { useCheckUsername } from "./api/check-username.ts"
 import {
 	InputGroup,
 	InputGroupAddon,
 	InputGroupInput,
 } from "@/components/ui/input-group"
-import { CircleCheckBig, CircleX, Loader2 } from "lucide-react"
-import { type AxiosError, HttpStatusCode } from "axios"
-import type { UseQueryResult } from "@tanstack/react-query"
+import UsernameStateIcon from "@/features/workspace/components/username-state-icon.tsx"
+import usernameCheckMessage from "@/features/workspace/utils/username-check-message.ts"
 
 const LAG_MS = 2500
-
-function usernameCheckMessage(
-	query: UseQueryResult<null, AxiosError<unknown, Error>>,
-	username: string,
-) {
-	if (username.length < MIN_USERNAME_LENGTH || !query.isError) return null
-
-	const status = query.error?.response?.status
-	if (status === HttpStatusCode.Conflict)
-		return "username taken, lets get creative!!"
-	if (status === HttpStatusCode.BadRequest)
-		return 'Invalid username pattern. Try something with pattern "john.doe" or just "john"'
-	return null
-}
-
-function UsernameStateIcon({
-	query,
-}: {
-	query: UseQueryResult<null, AxiosError<unknown, Error>>
-}) {
-	const icon = () => {
-		if (query.isSuccess) {
-			return (
-				<CircleCheckBig
-					data-testid="username-available"
-					className="size-4 text-green-600"
-				/>
-			)
-		}
-		if (
-			query.isError &&
-			(query.error?.response?.status === HttpStatusCode.Conflict ||
-				query.error?.response?.status === HttpStatusCode.BadRequest)
-		) {
-			return (
-				<CircleX
-					data-testid="username-error"
-					className="size-4 text-destructive"
-				/>
-			)
-		}
-		return (
-			<Loader2
-				data-testid="username-checking"
-				className="size-4 animate-spin text-neutral-400"
-			/>
-		)
-	}
-	return icon()
-}
 
 export function AcceptInvite() {
 	const { inviteCode } = useSearch({ from: "/workspace-invite" })

--- a/src/features/workspace/accept-invite.tsx
+++ b/src/features/workspace/accept-invite.tsx
@@ -54,7 +54,8 @@ function usernameCheckMessage(
 	if (username.length < MIN_USERNAME_LENGTH || !query.isError) return null
 
 	const status = query.error?.response?.status
-	if (status === HttpStatusCode.Conflict) return "username taken, lets get creative!!"
+	if (status === HttpStatusCode.Conflict)
+		return "username taken, lets get creative!!"
 	if (status === HttpStatusCode.BadRequest)
 		return 'Invalid username pattern. Try something with pattern "john.doe" or just "john"'
 	return null

--- a/src/features/workspace/components/username-state-icon.tsx
+++ b/src/features/workspace/components/username-state-icon.tsx
@@ -1,0 +1,39 @@
+import type { UseQueryResult } from "@tanstack/react-query"
+import { type AxiosError, HttpStatusCode } from "axios"
+import { CircleCheckBig, CircleX, Loader2 } from "lucide-react"
+
+export default function UsernameStateIcon({
+	query,
+}: {
+	query: UseQueryResult<null, AxiosError<unknown, Error>>
+}) {
+	const icon = () => {
+		if (query.isSuccess) {
+			return (
+				<CircleCheckBig
+					data-testid="username-available"
+					className="size-4 text-green-600"
+				/>
+			)
+		}
+		if (
+			query.isError &&
+			(query.error?.response?.status === HttpStatusCode.Conflict ||
+				query.error?.response?.status === HttpStatusCode.BadRequest)
+		) {
+			return (
+				<CircleX
+					data-testid="username-error"
+					className="size-4 text-destructive"
+				/>
+			)
+		}
+		return (
+			<Loader2
+				data-testid="username-checking"
+				className="size-4 animate-spin text-neutral-400"
+			/>
+		)
+	}
+	return icon()
+}

--- a/src/features/workspace/components/username-state-icon.tsx
+++ b/src/features/workspace/components/username-state-icon.tsx
@@ -7,33 +7,32 @@ export default function UsernameStateIcon({
 }: {
 	query: UseQueryResult<null, AxiosError<unknown, Error>>
 }) {
-	const icon = () => {
-		if (query.isSuccess) {
-			return (
-				<CircleCheckBig
-					data-testid="username-available"
-					className="size-4 text-green-600"
-				/>
-			)
-		}
-		if (
-			query.isError &&
-			(query.error?.response?.status === HttpStatusCode.Conflict ||
-				query.error?.response?.status === HttpStatusCode.BadRequest)
-		) {
-			return (
-				<CircleX
-					data-testid="username-error"
-					className="size-4 text-destructive"
-				/>
-			)
-		}
+	if (query.isSuccess) {
 		return (
-			<Loader2
-				data-testid="username-checking"
-				className="size-4 animate-spin text-neutral-400"
+			<CircleCheckBig
+				data-testid="username-available"
+				className="size-4 text-green-600"
 			/>
 		)
 	}
-	return icon()
+
+	const status = query.error?.response?.status
+	if (
+		query.isError &&
+		(status === HttpStatusCode.Conflict || status === HttpStatusCode.BadRequest)
+	) {
+		return (
+			<CircleX
+				data-testid="username-error"
+				className="size-4 text-destructive"
+			/>
+		)
+	}
+
+	return (
+		<Loader2
+			data-testid="username-checking"
+			className="size-4 animate-spin text-neutral-400"
+		/>
+	)
 }

--- a/src/features/workspace/utils/username-check-message.ts
+++ b/src/features/workspace/utils/username-check-message.ts
@@ -1,0 +1,17 @@
+import type { UseQueryResult } from "@tanstack/react-query"
+import { type AxiosError, HttpStatusCode } from "axios"
+import { MIN_USERNAME_LENGTH } from "@/features/workspace/api/check-username.ts"
+
+export default function usernameCheckMessage(
+	query: UseQueryResult<null, AxiosError<unknown, Error>>,
+	username: string,
+) {
+	if (username.length < MIN_USERNAME_LENGTH || !query.isError) return null
+
+	const status = query.error?.response?.status
+	if (status === HttpStatusCode.Conflict)
+		return "username taken, lets get creative!!"
+	if (status === HttpStatusCode.BadRequest)
+		return 'Invalid username pattern. Try something with pattern "john.doe" or just "john"'
+	return null
+}

--- a/src/features/workspace/workspace.page.tsx
+++ b/src/features/workspace/workspace.page.tsx
@@ -100,6 +100,7 @@ function WorkspaceAvatar({ workspace }: { workspace: Workspace }) {
 }
 
 export default function WorkspacePage() {
+	//TODO: before loading this ensure teammates are loaded.
 	const [openTeammateInviteModal, setOpenTeammateInviteModal] = useState(false)
 
 	const { code } = useSearch({ from: "/workspace" })

--- a/src/test/helpers/mocks.ts
+++ b/src/test/helpers/mocks.ts
@@ -35,21 +35,31 @@ export function mockAuthedUser(token = "fake-token") {
 export function mockGetUrls({ isAuthenticated = false } = {}) {
 	if (isAuthenticated) mockAuthedUser()
 
-	const routes = new Map<string, unknown>()
+	type RouteResult =
+		| { ok: true; data: unknown }
+		| { ok: false; status: HttpStatusCode }
+
+	const routes = new Map<string, RouteResult>()
 
 	const builder = {
 		url(url: string) {
 			return {
 				respond(data: unknown) {
-					routes.set(url, data)
+					routes.set(url, { ok: true, data })
+					return builder
+				},
+				fail(status: HttpStatusCode) {
+					routes.set(url, { ok: false, status })
 					return builder
 				},
 			}
 		},
 		apply() {
 			vi.mocked(apiClient.get).mockImplementation((url: string) => {
-				if (routes.has(url)) return Promise.resolve({ data: routes.get(url) })
-				return Promise.reject(new Error(`Unexpected GET ${url}`))
+				const route = routes.get(url)
+				if (!route) return Promise.reject(new Error(`Unexpected GET ${url}`))
+				if (!route.ok) return Promise.reject(mockError(route.status))
+				return Promise.resolve({ data: route.data })
 			})
 		},
 	}


### PR DESCRIPTION
## Summary

When a user inputs an invalid username, 👇  we need to let them know. 

<img width="653" height="588" alt="Screenshot 2026-08-02 at 08 03 12" src="https://github.com/user-attachments/assets/d544f784-bff6-4b14-bd21-81dfb0172cca" />


### Username Taken

<img width="993" height="962" alt="Screenshot 2026-08-02 at 08 28 13" src="https://github.com/user-attachments/assets/15f6625f-ba0f-48b3-9088-d6da132c15bb" />


### Invalid Pattern

<img width="707" height="977" alt="Screenshot 2026-08-02 at 08 28 55" src="https://github.com/user-attachments/assets/6434cc00-c36a-4417-b6b7-59a6dff310ee" />

