### PR TITLE
Add  username to signup payload

### DIFF
--- a/src/features/auth/schema/signupSchema.ts
+++ b/src/features/auth/schema/signupSchema.ts
@@ -25,6 +25,13 @@ export const signupSchema = z.object({
 		.nonempty({ message: "Work email is required" })
 		.trim()
 		.toLowerCase(),
+
+	username: z
+		.string()
+		.trim()
+		.toLowerCase()
+		.min(2, { message: "username must contain at least 5 characters" })
+		.max(20, { message: "Username is too large" }),
 })
 
 export type SignupData = z.infer<typeof signupSchema>

--- a/src/features/auth/signp-page.test.tsx
+++ b/src/features/auth/signp-page.test.tsx
@@ -10,9 +10,13 @@ import { HttpStatusCode } from "axios"
 import { RouterProvider } from "@tanstack/react-router"
 import { apiClient } from "@/lib/api-client"
 import { Pages } from "@/utils/pages.ts"
-import { mockError } from "@/test/helpers/mocks.ts"
+import { mockError, mockGetUrls } from "@/test/helpers/mocks.ts"
 import { makeAuthTestRouter } from "@/test/helpers/navigate"
 import { ApiPaths, CHECK_MAIL_REASON } from "@/constants.ts"
+
+vi.mock("@/hooks/use-debounce", () => ({
+	useDebounce: (value: unknown) => value,
+}))
 
 describe("Signup page", () => {
 	let user: UserEvent
@@ -25,6 +29,7 @@ describe("Signup page", () => {
 			lastName: "Doe",
 			email: "james@gmail.com",
 			companyName: "sandpaper",
+			username: "john.doe",
 			...details,
 		}
 	}
@@ -34,11 +39,16 @@ describe("Signup page", () => {
 		lastName: "last-name",
 		email: "email",
 		companyName: "company-name",
+		username: "teammate-username",
 		submit: "submit-button",
 		emailErrorMessage: "email-form-message",
 		firstNameErrorMessage: "firstname-form-message",
 		lastNameErrorMessage: "lastname-form-message",
 		companyNameErrorMessage: "companyname-form-message",
+	}
+
+	function mockUsernameAvailable() {
+		mockGetUrls().url(ApiPaths.CHECK_USERNAME).respond(null).apply()
 	}
 
 	async function setupSignupPage() {
@@ -61,6 +71,7 @@ describe("Signup page", () => {
 				await this.enterInput(signupDetails.firstName, formFields.firstName)
 				await this.enterInput(signupDetails.lastName, formFields.lastName)
 				await this.enterInput(signupDetails.email, formFields.email)
+				await this.enterInput(signupDetails.username, formFields.username)
 				await this.enterInput(signupDetails.companyName, formFields.companyName)
 			},
 			click: async (button: HTMLElement) => {
@@ -79,6 +90,7 @@ describe("Signup page", () => {
 			test.each(["invalid-email", "tum@c", " "])(
 				"should disable submit button for email %s",
 				async (email) => {
+					mockUsernameAvailable()
 					await setupSignupPage()
 
 					expect(
@@ -107,6 +119,7 @@ describe("Signup page", () => {
 			test.each([" ", "f", "d".repeat(19), "firstNameMoreThan!0Characters"])(
 				"should disable submit button for invalid first name %s",
 				async (firstName) => {
+					mockUsernameAvailable()
 					await setupSignupPage()
 					expect(
 						screen.queryByTestId(formFields.firstNameErrorMessage),
@@ -132,6 +145,7 @@ describe("Signup page", () => {
 			test.each([" ", "d", "d".repeat(19), "lastNameMoreThan!0Characters"])(
 				"should disable submit button for invalid last name %s",
 				async (lastName) => {
+					mockUsernameAvailable()
 					await setupSignupPage()
 					expect(
 						screen.queryByTestId(formFields.lastNameErrorMessage),
@@ -157,6 +171,7 @@ describe("Signup page", () => {
 			test.each([" ", "A".repeat(51)])(
 				"should disable submit button for invalid company name %s",
 				async (companyName) => {
+					mockUsernameAvailable()
 					await setupSignupPage()
 					expect(
 						screen.queryByTestId(formFields.companyNameErrorMessage),
@@ -177,10 +192,28 @@ describe("Signup page", () => {
 				},
 			)
 		})
+
+		describe("Username", () => {
+			test("should disable submit button when username is taken", async () => {
+				mockGetUrls()
+					.url(ApiPaths.CHECK_USERNAME)
+					.fail(HttpStatusCode.Conflict)
+					.apply()
+				await setupSignupPage()
+
+				await userInput.enterSignUpDetails({})
+
+				await waitFor(() => {
+					expect(screen.getByTestId("username-error")).toBeInTheDocument()
+					expect(screen.getByTestId(formFields.submit)).toBeDisabled()
+				})
+			})
+		})
 	})
 
 	describe("valid input", () => {
 		test("button is enabled when input is valid", async () => {
+			mockUsernameAvailable()
 			await setupSignupPage()
 
 			await userInput.enterSignUpDetails({})
@@ -193,6 +226,7 @@ describe("Signup page", () => {
 		})
 
 		test("successful signup navigates to check email page", async () => {
+			mockUsernameAvailable()
 			mockApiClientPost.mockResolvedValueOnce({} as never)
 
 			const queryClient = createTestQueryClient()
@@ -208,6 +242,7 @@ describe("Signup page", () => {
 			await userInput.enterSignUpDetails(signupDetails)
 
 			const submitButton = screen.getByTestId(formFields.submit)
+			await waitFor(() => expect(submitButton).toBeEnabled())
 			await userInput.click(submitButton)
 
 			await waitFor(() => {
@@ -238,6 +273,7 @@ describe("Signup page", () => {
 				)
 			})
 			test("when user is unauthorized we transition to waitlist page", async () => {
+				mockUsernameAvailable()
 				const queryClient = createTestQueryClient()
 				const router = makeAuthTestRouter()
 				const navigateSpy = vi.spyOn(router, "navigate")
@@ -249,6 +285,7 @@ describe("Signup page", () => {
 				await userInput.enterSignUpDetails({})
 
 				const submitButton = screen.getByTestId(formFields.submit)
+				await waitFor(() => expect(submitButton).toBeEnabled())
 				await userInput.click(submitButton)
 
 				await waitFor(() => {

--- a/src/features/auth/signup-page.tsx
+++ b/src/features/auth/signup-page.tsx
@@ -240,7 +240,9 @@ const SignupPage = () => {
 						/>
 
 						<Button
-							disabled={!form.formState.isValid || isPending}
+							disabled={
+								!form.formState.isValid || isPending || !usernameQuery.isSuccess
+							}
 							type="submit"
 							className="mt-2 h-11 w-full cursor-pointer rounded-lg bg-[#1A1C23] text-white hover:bg-[#1A1C23]/90"
 							data-testid="submit-button"

--- a/src/features/auth/signup-page.tsx
+++ b/src/features/auth/signup-page.tsx
@@ -22,6 +22,15 @@ import { Pages } from "@/utils/pages.ts"
 import { toast } from "sonner"
 import { SplitLayout } from "@/common/components/split-layout.tsx"
 import { CHECK_MAIL_REASON } from "@/constants.ts"
+import {
+	InputGroup,
+	InputGroupAddon,
+	InputGroupInput,
+} from "@/components/ui/input-group.tsx"
+import UsernameStateIcon from "@/features/workspace/components/username-state-icon.tsx"
+import usernameCheckMessage from "@/features/workspace/utils/username-check-message.ts"
+import { useDebounce } from "@/hooks/use-debounce.ts"
+import { useCheckUsername } from "@/features/workspace/api/check-username.ts"
 
 const SignupPage = () => {
 	const { mutate: signupUser, isPending } = useSignup()
@@ -35,8 +44,13 @@ const SignupPage = () => {
 			lastName: "",
 			email: "",
 			companyName: "",
+			username: "",
 		},
 	})
+
+	const username = form.watch("username")
+	const debouncedUsername = useDebounce(username, 300)
+	const usernameQuery = useCheckUsername(debouncedUsername)
 
 	const onSubmit = (data: SignupData) => {
 		const signUpdata = {
@@ -159,6 +173,47 @@ const SignupPage = () => {
 										No work email? We accept personal emails too.
 									</FormDescription>
 									<FormMessage data-testid="email-form-message" />
+								</FormItem>
+							)}
+						/>
+
+						<FormField
+							control={form.control}
+							name="username"
+							render={({ field }) => (
+								<FormItem className="gap-2">
+									<FormLabel className="font-semibold text-neutral-800">
+										Username
+									</FormLabel>
+									<FormControl>
+										<InputGroup>
+											<InputGroupInput
+												data-testid="teammate-username"
+												placeholder="john.doe"
+												className="signup-field-input"
+												{...field}
+											/>
+											<InputGroupAddon align="inline-end">
+												{username && (
+													<UsernameStateIcon query={usernameQuery} />
+												)}
+											</InputGroupAddon>
+										</InputGroup>
+									</FormControl>
+									<FormMessage
+										className="text-xs"
+										data-testid="teammate-username-form-message"
+									>
+										{usernameCheckMessage(usernameQuery, username)}
+									</FormMessage>
+									<FormDescription className="text-xs text-neutral-500">
+										This is how teammates will see you. Keep it simple and easy
+										to find, something like{" "}
+										<code className="bg-gray-100 px-1 rounded">
+											first.lastname
+										</code>{" "}
+										works great!
+									</FormDescription>
 								</FormItem>
 							)}
 						/>

--- a/src/features/workspace/accept-invite.test.tsx
+++ b/src/features/workspace/accept-invite.test.tsx
@@ -171,7 +171,7 @@ describe("AcceptInvite", () => {
 			await user.clear(screen.getByTestId("teammate-username"))
 
 			await waitFor(() => {
-                expect(screen.queryByTestId("username-error")).not.toBeInTheDocument()
+				expect(screen.queryByTestId("username-error")).not.toBeInTheDocument()
 				expect(screen.queryByTestId("username-taken")).not.toBeInTheDocument()
 			})
 			expect(

--- a/src/features/workspace/accept-invite.test.tsx
+++ b/src/features/workspace/accept-invite.test.tsx
@@ -171,12 +171,17 @@ describe("AcceptInvite", () => {
 			await user.clear(screen.getByTestId("teammate-username"))
 
 			await waitFor(() => {
-				expect(screen.queryByTestId("username-error")).not.toBeInTheDocument()
-				expect(screen.queryByText("Username taken")).not.toBeInTheDocument()
+                expect(screen.queryByTestId("username-error")).not.toBeInTheDocument()
+				expect(screen.queryByTestId("username-taken")).not.toBeInTheDocument()
 			})
+			expect(
+				screen.getByTestId("teammate-username-form-message"),
+			).toHaveTextContent(
+				'Invalid username pattern. Try something with pattern "john.doe" or just "john"',
+			)
 		})
 
-		it("shows invalid username message when check-username returns BadRequest (400)", async () => {
+		it("shows username taken icon when check-username returns BadRequest (400)", async () => {
 			mockGetUrls()
 				.url(ApiPaths.VERIFY_INVITE)
 				.respond(fakeInvite)
@@ -188,13 +193,8 @@ describe("AcceptInvite", () => {
 			await user.type(screen.getByTestId("teammate-username"), "bad.name")
 
 			await waitFor(() => {
-				expect(screen.getByTestId("username-error")).toBeInTheDocument()
+				expect(screen.getByTestId("username-taken")).toBeInTheDocument()
 			})
-			expect(
-				screen.getByTestId("teammate-username-form-message"),
-			).toHaveTextContent(
-				'Invalid username pattern. Try something with pattern "john.doe" or just "john"',
-			)
 		})
 	})
 })

--- a/src/features/workspace/accept-invite.test.tsx
+++ b/src/features/workspace/accept-invite.test.tsx
@@ -181,7 +181,7 @@ describe("AcceptInvite", () => {
 			)
 		})
 
-		it("shows invalid username message when check-username returns BadRequest (400)", async () => {
+		it("shows invalid username message and disables submit when check-username returns BadRequest (400)", async () => {
 			mockGetUrls()
 				.url(ApiPaths.VERIFY_INVITE)
 				.respond(fakeInvite)
@@ -190,6 +190,8 @@ describe("AcceptInvite", () => {
 				.apply()
 
 			await renderAndWaitForForm()
+			await user.type(screen.getByTestId("teammate-first-name"), "John")
+			await user.type(screen.getByTestId("teammate-last-name"), "Doe")
 			await user.type(screen.getByTestId("teammate-username"), "bad.name")
 
 			await waitFor(() => {
@@ -200,6 +202,7 @@ describe("AcceptInvite", () => {
 			).toHaveTextContent(
 				'Invalid username pattern. Try something with pattern "john.doe" or just "john"',
 			)
+			expect(screen.getByTestId("submit-button")).toBeDisabled()
 		})
 	})
 })

--- a/src/features/workspace/accept-invite.test.tsx
+++ b/src/features/workspace/accept-invite.test.tsx
@@ -181,7 +181,7 @@ describe("AcceptInvite", () => {
 			)
 		})
 
-		it("shows username taken icon when check-username returns BadRequest (400)", async () => {
+		it("shows invalid username message when check-username returns BadRequest (400)", async () => {
 			mockGetUrls()
 				.url(ApiPaths.VERIFY_INVITE)
 				.respond(fakeInvite)
@@ -193,8 +193,13 @@ describe("AcceptInvite", () => {
 			await user.type(screen.getByTestId("teammate-username"), "bad.name")
 
 			await waitFor(() => {
-				expect(screen.getByTestId("username-taken")).toBeInTheDocument()
+				expect(screen.getByTestId("username-error")).toBeInTheDocument()
 			})
+			expect(
+				screen.getByTestId("teammate-username-form-message"),
+			).toHaveTextContent(
+				'Invalid username pattern. Try something with pattern "john.doe" or just "john"',
+			)
 		})
 	})
 })

--- a/src/features/workspace/accept-invite.test.tsx
+++ b/src/features/workspace/accept-invite.test.tsx
@@ -174,11 +174,6 @@ describe("AcceptInvite", () => {
 				expect(screen.queryByTestId("username-error")).not.toBeInTheDocument()
 				expect(screen.queryByTestId("username-taken")).not.toBeInTheDocument()
 			})
-			expect(
-				screen.getByTestId("teammate-username-form-message"),
-			).toHaveTextContent(
-				'Invalid username pattern. Try something with pattern "john.doe" or just "john"',
-			)
 		})
 
 		it("shows invalid username message and disables submit when check-username returns BadRequest (400)", async () => {

--- a/src/features/workspace/accept-invite.tsx
+++ b/src/features/workspace/accept-invite.tsx
@@ -253,7 +253,9 @@ export function AcceptInvite() {
 
 							<Button
 								disabled={
-									!form.formState.isValid || isPending || usernameQuery.isError
+									!form.formState.isValid ||
+									isPending ||
+									!usernameQuery.isSuccess
 								}
 								type="submit"
 								className="mt-2 h-11 w-full cursor-pointer rounded-lg bg-[#1A1C23] text-white hover:bg-[#1A1C23]/90"

--- a/src/features/workspace/api/check-username.ts
+++ b/src/features/workspace/api/check-username.ts
@@ -6,7 +6,7 @@ import { ApiPaths } from "@/constants.ts"
 export const CHECK_USERNAME = "checkUsername"
 export const MIN_USERNAME_LENGTH = 2
 
-export function useCheckUsername(username: string, workspaceCode: string) {
+export function useCheckUsername(username: string, workspaceCode?: string) {
 	return useQuery<null, AxiosError>({
 		queryKey: [CHECK_USERNAME, workspaceCode, username],
 		queryFn: () =>
@@ -19,7 +19,7 @@ export function useCheckUsername(username: string, workspaceCode: string) {
 				})
 				.then(() => null),
 		enabled:
-			username.length >= MIN_USERNAME_LENGTH && workspaceCode.length !== 0, // workspace might not have loaded why we added the check
+			username.length >= MIN_USERNAME_LENGTH && workspaceCode?.length !== 0, // workspace might not have loaded why we added the check
 		retry: false,
 		staleTime: 1000 * 60,
 	})


### PR DESCRIPTION
## Summary

We've added a username field to the user signup form 🤔. This lets users set their username on first signup.

<img width="684" height="965" alt="Screenshot 2026-08-02 at 16 06 39" src="https://github.com/user-attachments/assets/88ee4e81-e267-4af1-a1dd-585d97b9d0d9" />


Previously, we defaulted to `firstname.lastname`; now we set whatever you put 👇 


<img width="1708" height="876" alt="Screenshot 2026-08-02 at 16 07 56" src="https://github.com/user-attachments/assets/c967f1fa-038c-4c3b-b60f-10f5924e29e5" />
